### PR TITLE
Feature/create signup form

### DIFF
--- a/front/src/components/Login.vue
+++ b/front/src/components/Login.vue
@@ -1,9 +1,82 @@
 <template>
-    <h1>login</h1>
+<v-app>
+    <v-card width="400px" class="mx-auto mt-5">
+        <v-card-title>
+            <h1 class="display-1">ログイン</h1>
+        </v-card-title>
+        <v-card-text>
+            <v-form ref="loginForm">
+
+                <v-text-field label="メールアドレス"
+                    prepend-icon="mdi-account-circle"
+                    v-model="model.email" 
+                    :counter="128"
+                    :rules="emailRules"/>
+
+                <v-text-field label="パスワード"
+                    prepend-icon="mdi-lock" 
+                    v-bind:append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'" 
+                    v-bind:type="showPassword ? 'text' : 'password'" 
+                    @click:append="showPassword = !showPassword"
+                    v-model="model.password"
+                    :counter="32"
+                    :rules="passwordRules" />
+                    
+                <v-card-actions>
+                    <v-btn @click="login">ログイン</v-btn>
+                </v-card-actions>
+            </v-form>
+        </v-card-text>
+    </v-card>
+</v-app>
 </template>
 
 <script>
 export default {
+
+    data: function() {
+        return {
+            model: {
+                email : "",
+                password : "",
+            },
+
+            showPassword : false,
+
+            emailRules: [
+                v => !!v || "メールアドレスは必須項目です。",
+                v => (v && v.length <= 128) || "メールアドレスは128文字以内で入力してください。",
+                v => /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(v) || "メールアドレスの形式が正しくありません。"
+            ],
+            passwordRules: [
+                v => !!v || "パスワードは必須項目です。",
+                v => (v && v.length <= 32) || "パスワードは32文字以内で入力してください。"
+            ],
+        }
+    },
+
+    methods: {
+        login: function() {
+            if (this.$refs.loginForm.validate()) {
+                if(this.check_database()) {
+                    this.$router.push('/map')
+                }
+                else {
+                    console.log("failed to send database")
+                    
+                }
+            }
+            else {
+                console.log("failed to register")
+            }
+
+        },
+
+        check_database: function() {
+            //TODO: ログインできるか確認
+            return true
+        }
+    }
     
 }
 </script>

--- a/front/src/components/Login.vue
+++ b/front/src/components/Login.vue
@@ -8,7 +8,7 @@
             <v-form ref="loginForm">
 
                 <v-text-field label="メールアドレス"
-                    prepend-icon="mdi-account-circle"
+                    prepend-icon="mdi-email"
                     v-model="model.email" 
                     :counter="128"
                     :rules="emailRules"/>

--- a/front/src/components/Signup.vue
+++ b/front/src/components/Signup.vue
@@ -13,7 +13,7 @@
                     @click:append="showPassword = !showPassword"
                     label="パスワード" />
                 <v-card-actions>
-                    <v-btn>ログイン</v-btn>
+                    <v-btn @click="register">ログイン</v-btn>
                 </v-card-actions>
             </v-form>
         </v-card-text>
@@ -23,10 +23,21 @@
 
 <script>
 export default {
-    name: 'login',
-    data: () => ({
-        showPassword : false
-    })
+
+    data: function() {
+        return {
+            showPassword : false
+        }
+    },
+
+    methods: {
+        register: function() {
+            //
+            // TODO: アカウントを作成できるかチェックする必要がある
+            //
+            this.$router.push('/map')
+        }
+    }
     
 }
 </script>

--- a/front/src/components/Signup.vue
+++ b/front/src/components/Signup.vue
@@ -13,7 +13,7 @@
                     :rules="usernameRules"/>
 
                 <v-text-field label="メールアドレス"
-                    prepend-icon="mdi-account-circle"
+                    prepend-icon="mdi-email"
                     v-model="model.email" 
                     :counter="128"
                     :rules="emailRules"/>

--- a/front/src/components/Signup.vue
+++ b/front/src/components/Signup.vue
@@ -1,9 +1,32 @@
 <template>
-    <h1>signup</h1>
+<v-app>
+    <v-card width="400px" class="mx-auto mt-5">
+        <v-card-title>
+            <h1 class="display-1">ログイン</h1>
+        </v-card-title>
+        <v-card-text>
+            <v-form>
+                <v-text-field prepend-icon="mdi-account-circle" label="ユーザ名" />
+                <v-text-field prepend-icon="mdi-lock" 
+                    v-bind:append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'" 
+                    v-bind:type="showPassword ? 'text' : 'password'" 
+                    @click:append="showPassword = !showPassword"
+                    label="パスワード" />
+                <v-card-actions>
+                    <v-btn>ログイン</v-btn>
+                </v-card-actions>
+            </v-form>
+        </v-card-text>
+    </v-card>
+</v-app>
 </template>
 
 <script>
 export default {
+    name: 'login',
+    data: () => ({
+        showPassword : false
+    })
     
 }
 </script>

--- a/front/src/components/Signup.vue
+++ b/front/src/components/Signup.vue
@@ -2,16 +2,31 @@
 <v-app>
     <v-card width="400px" class="mx-auto mt-5">
         <v-card-title>
-            <h1 class="display-1">ログイン</h1>
+            <h1 class="display-1">新規登録</h1>
         </v-card-title>
         <v-card-text>
-            <v-form>
-                <v-text-field prepend-icon="mdi-account-circle" label="ユーザ名" />
-                <v-text-field prepend-icon="mdi-lock" 
+            <v-form ref="loginForm">
+                <v-text-field label="ユーザ名"
+                    prepend-icon="mdi-account-circle"
+                    v-model="model.username" 
+                    :counter="32"
+                    :rules="usernameRules"/>
+
+                <v-text-field label="メールアドレス"
+                    prepend-icon="mdi-account-circle"
+                    v-model="model.email" 
+                    :counter="128"
+                    :rules="emailRules"/>
+
+                <v-text-field label="パスワード"
+                    prepend-icon="mdi-lock" 
                     v-bind:append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'" 
                     v-bind:type="showPassword ? 'text' : 'password'" 
                     @click:append="showPassword = !showPassword"
-                    label="パスワード" />
+                    v-model="model.password"
+                    :counter="32"
+                    :rules="passwordRules" />
+                    
                 <v-card-actions>
                     <v-btn @click="register">ログイン</v-btn>
                 </v-card-actions>
@@ -26,16 +41,55 @@ export default {
 
     data: function() {
         return {
-            showPassword : false
+            model: {
+                username : "",
+                email : "",
+                password : "",
+            },
+
+            showPassword : false,
+            usernameRules: [
+                v => !!v || "ユーザ名は必須項目です。",
+                v => (v && v.length <= 32) || "ユーザ名は32文字以内で入力してください。",
+            ],
+            emailRules: [
+                v => !!v || "メールアドレスは必須項目です。",
+                v => (v && v.length <= 128) || "メールアドレスは128文字以内で入力してください。",
+                v => /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(v) || "メールアドレスの形式が正しくありません。"
+            ],
+            passwordRules: [
+                v => !!v || "パスワードは必須項目です。",
+                v => (v && v.length <= 32) || "パスワードは32文字以内で入力してください。"
+            ],
         }
     },
 
     methods: {
         register: function() {
-            //
-            // TODO: アカウントを作成できるかチェックする必要がある
-            //
-            this.$router.push('/map')
+            if (this.$refs.loginForm.validate()) {
+                if(this.check_database()) {
+                    this.create_account()
+                    this.$router.push('/map')
+                }
+                else {
+                    console.log("failed to send database")
+                    
+                }
+            }
+            else {
+                console.log("failed to register")
+            }
+
+        },
+
+        check_database: function() {
+            //TODO: アカウントを作成できるか確認
+            return true
+        },
+
+        create_account: function() {
+            //TODO: アカウントを作成する処理
+            console.log("create_account")
         }
     }
     


### PR DESCRIPTION
【実装内容】
アカウント作成とログインの入力フォームを作成した  
入力内容が適切でない場合はエラーメッセージを表示する
適切な入力内容で登録/ログインボタンを押すとマップページに遷移する
データベース関連の処理はまだ実装していない

【テスト手順】
1. 新規登録/ログインページに移動する
2. 入力フォームに情報を記入する
3. 登録/ログインボタンを押す
    - 入力内容が適切である場合、マップページに遷移する
    - 適切でない場合、遷移できず、エラーメッセージが表示される

【関連issue】
#8 #30