### PR TITLE
Feature/17 show map

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ansur/leaflet-pulse-icon": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@ansur/leaflet-pulse-icon/-/leaflet-pulse-icon-0.1.1.tgz",
+      "integrity": "sha512-2vymis4WMiacers0JJ43Ku0TjdKypnh0atMdFC2VdTGd5G/NGsmW5eYnTZr1YHNOts3CXRbnwlkEMKB7OPsfIg==",
+      "requires": {
+        "leaflet": ">=0.7.3"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",

--- a/front/package.json
+++ b/front/package.json
@@ -12,6 +12,7 @@
   },
   "main": "index.js",
   "dependencies": {
+    "@ansur/leaflet-pulse-icon": "^0.1.1",
     "core-js": "^3.6.5",
     "leaflet": "^1.7.1",
     "vue": "^2.6.12",

--- a/front/src/components/Map/Map.js
+++ b/front/src/components/Map/Map.js
@@ -1,0 +1,113 @@
+import  'leaflet/dist/leaflet.css'
+import  L from 'leaflet'
+import spotRegButton from './MapButtons/SpotRegButton.vue'
+import nowLocButton from './MapButtons/NowLocButton.vue'
+import typeButton from './MapButtons/TypeButton.vue'
+
+delete  L.Icon.Default.prototype._getIconUrl
+
+L.Icon.Default.mergeOptions(
+    {   iconUrl         : require( 'leaflet/dist/images/marker-icon.png' )
+    ,   iconRetinaUrl   : require( 'leaflet/dist/images/marker-icon-2x.png' )
+    ,   shadowUrl       : require( 'leaflet/dist/images/marker-shadow.png' )
+    }
+)
+
+
+export default {
+    name: "Map",
+    components:{
+      spotRegButton,
+      nowLocButton,
+      typeButton,
+    },
+    data: function(){
+      return {
+        lat:0,//緯度
+        lon:0,//経度
+        map: L.map,//Mapオブジェクト
+        zoom:15,//zoomのサイズ まだうまく制御できてない(SATD)
+        spot:null,//spot用のオブジェクト
+        myplace:null,//現在地オブジェクト
+        regFlag:false,//スポット登録モードのフラグ
+        flag :false,//実装上の都合で導入したフラグ
+        locMarker:null,//現在地のマーカーオブジェクト     
+        nowType:'reset',//スポット検索の種別
+      };
+    },
+    methods: {
+    //Map上のどこかををクリックした時に起動する関数
+      mapClickEvent(event){
+        if(this.flag){
+          this.flag=false
+          this.getPoint(event);
+          this.regSpot(event);
+        }else{this.flag=true;}
+      },
+    //Map上のクリックされた箇所の経緯度を取得する関数
+      getPoint: function(event){
+        this.lat = event.latlng.lat;
+        this.lon = event.latlng.lng;
+      },
+      //Markerがクリックされた時に起動する関数
+      markerClickEvent(event){
+        console.log(event.latlng);//debug
+        console.log(this.nowType)//debug
+
+      },
+      //現在地アイコンを更新する関数(予定)
+      locationMarker(){
+        //this.locMarker = L.marker(location.latlng,{icon:this.currentLocationIcon}).addTo(this.map)//debug
+      },
+      //スポット登録関数
+      //SATD:経緯度をリンクで渡しているが、propsで渡す
+      regSpot: function(){
+        this.$router.push({ name: 'register', query: { "lat": this.lat,"lon":this.lon}});
+      },
+      //通常モードと登録モードの切り替え関数
+      changeMode: function(){
+        this.regFlag = !this.regFlag;
+        if(this.regFlag){
+        this.flag=false
+        this.map.on('click', this.mapClickEvent);
+        }
+        else{
+        this.map.off('click')
+        }
+      },
+      //マップの中心を現在地に更新する関数
+      nowLocation: function(){
+        this.map.locate({ setView: true,maxZoom: 18});
+        //現在地マーカーを設置
+        //this.map.on("locationfound",this.locationMarker);
+      },
+      //検索ジャンルを更新するメソッド
+      updateType(type){
+        this.nowType = type
+        console.log(this.nowType)//debug
+      },
+    },
+    mounted: function() {
+      //Mapオブジェクトの生成
+      this.map = L.map('map',{zoom: this.zoom})
+      .addLayer(
+        L.tileLayer("https://{s}.tile.osm.org/{z}/{x}/{y}.png", {
+          attribution:
+            'Map data &copy <a href="https://openstreetmap.org">OpenStreetMap</a>'
+        })
+      );
+
+      //初期位置を現在地に
+      this.map.locate({ setView: true,maxZoom: 18});
+
+      //現在地マーカーを設置(予定)
+        //this.map.on("locationfound",this.locationMarker);
+
+      //マーカーの登録とマーカークリック時に起動する関数の登録
+      this.marker = L.marker([33.3623,130.2505],{ title: "sample spot"}).addTo(this.map).on(
+        'click', this.markerClickEvent);
+    }, 
+    //現在地追跡のために利用(予定)
+    watch: {
+    }
+}

--- a/front/src/components/Map/Map.js
+++ b/front/src/components/Map/Map.js
@@ -13,7 +13,6 @@ L.Icon.Default.mergeOptions(
     }
 )
 
-
 export default {
     name: "Map",
     components:{
@@ -32,7 +31,7 @@ export default {
         regFlag:false,//スポット登録モードのフラグ
         flag :false,//実装上の都合で導入したフラグ
         locMarker:null,//現在地のマーカーオブジェクト 
-        nowType:'reset',//スポット検索の種別
+        nowType:'reset',//スポット検索の種別 "reset" "restaurant" "travel" "shopping"
       };
     },
     methods: {
@@ -44,26 +43,30 @@ export default {
           this.regSpot(event);
         }else{this.flag=true;}
       },
+
     //Map上のクリックされた箇所の経緯度を取得する関数
       getPoint: function(event){
         this.lat = event.latlng.lat;
         this.lon = event.latlng.lng;
       },
+
       //Markerがクリックされた時に起動する関数
       markerClickEvent(event){
         console.log(event.latlng);//debug
         console.log(this.nowType)//debug
-
       },
+
       //現在地アイコンを更新する関数(予定)
       locationMarker(){
         //this.locMarker = L.marker(location.latlng,{icon:this.currentLocationIcon}).addTo(this.map)//debug
       },
+
       //スポット登録関数
       //SATD:経緯度をリンクで渡しているが、propsで渡す
       regSpot: function(){
         this.$router.push({ name: 'register', query: { "lat": this.lat,"lon":this.lon}});
       },
+      
       //通常モードと登録モードの切り替え関数
       changeMode: function(){
         this.regFlag = !this.regFlag;
@@ -75,18 +78,21 @@ export default {
         this.map.off('click')
         }
       },
+
       //マップの中心を現在地に更新する関数
       nowLocation: function(){
         this.map.locate({ setView: true,maxZoom: 18});
         //現在地マーカーを設置
         //this.map.on("locationfound",this.locationMarker);
       },
-      //検索ジャンルを更新するメソッド
+
+      //検索ジャンルを更新するメソッド(TypeButton.vueから呼ばれる)
       updateType(type){
         this.nowType = type
         console.log(this.nowType)//debug
       },
     },
+
     mounted: function() {
       //Mapオブジェクトの生成
       this.map = L.map('map',{zoom: this.zoom})

--- a/front/src/components/Map/Map.js
+++ b/front/src/components/Map/Map.js
@@ -31,7 +31,7 @@ export default {
         myplace:null,//現在地オブジェクト
         regFlag:false,//スポット登録モードのフラグ
         flag :false,//実装上の都合で導入したフラグ
-        locMarker:null,//現在地のマーカーオブジェクト     
+        locMarker:null,//現在地のマーカーオブジェクト 
         nowType:'reset',//スポット検索の種別
       };
     },

--- a/front/src/components/Map/Map.js
+++ b/front/src/components/Map/Map.js
@@ -66,7 +66,7 @@ export default {
       regSpot: function(){
         this.$router.push({ name: 'register', query: { "lat": this.lat,"lon":this.lon}});
       },
-      
+
       //通常モードと登録モードの切り替え関数
       changeMode: function(){
         this.regFlag = !this.regFlag;
@@ -80,7 +80,7 @@ export default {
       },
 
       //マップの中心を現在地に更新する関数
-      nowLocation: function(){
+      setNowLocation: function(){
         this.map.locate({ setView: true,maxZoom: 18});
         //現在地マーカーを設置
         //this.map.on("locationfound",this.locationMarker);

--- a/front/src/components/Map/Map.vue
+++ b/front/src/components/Map/Map.vue
@@ -2,7 +2,7 @@
 <!-- mapレイヤのような形で生成される -->
   <div id='map'>
     <!-- spot種別検索メニュー -->
-    <type-button/>
+    <type-button @update-type="updateType"/>
     <!-- 通常モードとスポット登録モードの切り替えボタン -->
     <spot-reg-button :regFlag="regFlag" v-on:click.native="changeMode()"/>
     <!-- 現在地ボタン -->
@@ -10,116 +10,7 @@
   </div>
 </template>
 
-<script>
-import  'leaflet/dist/leaflet.css'
-import  L from 'leaflet'
-import spotRegButton from './MapButtons/SpotRegButton.vue'
-import nowLocButton from './MapButtons/NowLocButton.vue'
-import typeButton from './MapButtons/TypeButton.vue'
-
-delete  L.Icon.Default.prototype._getIconUrl
-
-L.Icon.Default.mergeOptions(
-    {   iconUrl         : require( 'leaflet/dist/images/marker-icon.png' )
-    ,   iconRetinaUrl   : require( 'leaflet/dist/images/marker-icon-2x.png' )
-    ,   shadowUrl       : require( 'leaflet/dist/images/marker-shadow.png' )
-    }
-)
-
-
-export default {
-    name: "Map",
-    components:{
-      spotRegButton,
-      nowLocButton,
-      typeButton,
-    },
-    data: function(){
-      return {
-        lat:0,//緯度
-        lon:0,//経度
-        map: L.map,//Mapオブジェクト
-        zoom:15,//zoomのサイズ まだうまく制御できてない(SATD)
-        spot:null,//spot用のオブジェクト
-        myplace:null,//現在地オブジェクト
-        regFlag:false,//スポット登録モードのフラグ
-        flag :false,//実装上の都合で導入したフラグ
-        locMarker:null,//現在地のマーカーオブジェクト     
-        nowType:'reset',//スポット検索の種別
-      };
-    },
-    methods: {
-    //Map上のどこかををクリックした時に起動する関数
-      mapClickEvent(event){
-        if(this.flag){
-          this.flag=false
-          this.getPoint(event);
-          this.regSpot(event);
-        }else{this.flag=true;}
-      },
-    //Map上のクリックされた箇所の経緯度を取得する関数
-      getPoint: function(event){
-        this.lat = event.latlng.lat;
-        this.lon = event.latlng.lng;
-      },
-      //Markerがクリックされた時に起動する関数
-      markerClickEvent(event){
-        console.log(event.latlng);//debug
-        console.log(this.nowType)//debug
-
-      },
-      //現在地アイコンを更新する関数(予定)
-      locationMarker(){
-        //this.locMarker = L.marker(location.latlng,{icon:this.currentLocationIcon}).addTo(this.map)//debug
-      },
-      //スポット登録関数
-      //SATD:経緯度をリンクで渡しているが、propsで渡す
-      regSpot: function(){
-        this.$router.push({ name: 'register', query: { "lat": this.lat,"lon":this.lon}});
-      },
-      //通常モードと登録モードの切り替え関数
-      changeMode: function(){
-        this.regFlag = !this.regFlag;
-        if(this.regFlag){
-        this.flag=false
-        this.map.on('click', this.mapClickEvent);
-        }
-        else{
-        this.map.off('click')
-        }
-      },
-      //マップの中心を現在地に更新する関数
-      nowLocation: function(){
-        this.map.locate({ setView: true,maxZoom: 18});
-        //現在地マーカーを設置
-        //this.map.on("locationfound",this.locationMarker);
-      },
-    },
-    mounted: function() {
-      //Mapオブジェクトの生成
-      this.map = L.map('map',{zoom: this.zoom})
-      .addLayer(
-        L.tileLayer("https://{s}.tile.osm.org/{z}/{x}/{y}.png", {
-          attribution:
-            'Map data &copy <a href="https://openstreetmap.org">OpenStreetMap</a>'
-        })
-      );
-
-      //初期位置を現在地に
-      this.map.locate({ setView: true,maxZoom: 18});
-
-      //現在地マーカーを設置(予定)
-        //this.map.on("locationfound",this.locationMarker);
-
-      //マーカーの登録とマーカークリック時に起動する関数の登録
-      this.marker = L.marker([33.3623,130.2505],{ title: "sample spot"}).addTo(this.map).on(
-        'click', this.markerClickEvent);
-    }, 
-    //現在地追跡のために利用(予定)
-    watch: {
-    }
-}
-</script>
+<script lang='js' src='./Map.js' />
 
 <style scoped>
 /* むやみにいじると地図表示が消えるので注意*/
@@ -136,10 +27,5 @@ body {
 }
   /* 各オブジェクトのstyleでz-indexを0以上に設定する 
   基本は1000でOK*/
-#v-list-item,
-#feature-menu,
-#feature-button,
-#feature-list{
-  z-index: 1000;
-}
+
 </style>

--- a/front/src/components/Map/Map.vue
+++ b/front/src/components/Map/Map.vue
@@ -2,102 +2,20 @@
 <!-- mapレイヤのような形で生成される -->
   <div id='map'>
     <!-- spot種別検索メニュー -->
-    <v-menu
-      id='feature-menu'
-      class="mx-15 my-5"
-      bottom
-      offset-x
-    >
-    <!-- クリックするとメニューが表示する -->
-    <template v-slot:activator="{ on, attrs }">
-      <v-btn
-        id='feature-button'
-        class="mx-15 my-5"
-        left
-        fab
-        v-bind="attrs"
-        v-on="on"
-      >
-
-      <!-- 現在の検索種別のアイコンを表示 -->
-      <v-icon
-      class="px-5"
-      large
-      >
-      {{featureIcons[nowType]}}
-     </v-icon>
-      </v-btn>
-      <!-- 検索メニュー -->
-      </template>
-        <v-list 
-        id='feature-list' 
-        absolute
-        >
-        <v-list-item
-          v-for="(type,index) in types"
-          :key="index"
-          link
-        >
-          <v-list-item-title
-          v-on:click="changeSearchType(type.title)"
-          >{{ type.title }}</v-list-item-title>
-        </v-list-item>
-      </v-list>
-    </v-menu>
-
+    <type-button/>
     <!-- 通常モードとスポット登録モードの切り替えボタン -->
-    <v-btn 
-      id='map-reg'
-      class="mx-4 my-5"
-      absolute
-      right
-      fab
-      v-on:click="changeMode()"
-    >
-    <!-- 通常モードアイコン -->
-     <v-icon
-      v-if="!regFlag"
-      class="px-5"
-      large
-      >
-        mdi-earth
-     </v-icon>
-      <!-- 登録モードアイコン -->
-     <v-icon
-      v-if="regFlag"
-      class="px-5"
-      color="#CC1651"
-      large
-      >
-        mdi-map-marker-plus
-     </v-icon>
-    </v-btn>
-
+    <spot-reg-button :regFlag="regFlag" v-on:click.native="changeMode()"/>
     <!-- 現在地ボタン -->
-    <v-btn
-    id='now-loc'
-    absolute
-    class="mx-4 my-15"
-    right
-    bottom
-    fab
-    v-on:click="nowLocation()"
-    >
-    <v-icon
-      color="#5D8C99"
-      class="px-5"
-      large 
-      >
-        mdi-crosshairs-gps
-    </v-icon>
-    </v-btn>
-
+    <now-loc-button v-on:click.native="nowLocation()"/>
   </div>
 </template>
 
 <script>
 import  'leaflet/dist/leaflet.css'
 import  L from 'leaflet'
+import spotRegButton from './MapButtons/SpotRegButton.vue'
+import nowLocButton from './MapButtons/NowLocButton.vue'
+import typeButton from './MapButtons/TypeButton.vue'
 
 delete  L.Icon.Default.prototype._getIconUrl
 
@@ -111,6 +29,11 @@ L.Icon.Default.mergeOptions(
 
 export default {
     name: "Map",
+    components:{
+      spotRegButton,
+      nowLocButton,
+      typeButton,
+    },
     data: function(){
       return {
         lat:0,//緯度
@@ -123,17 +46,6 @@ export default {
         flag :false,//実装上の都合で導入したフラグ
         locMarker:null,//現在地のマーカーオブジェクト     
         nowType:'reset',//スポット検索の種別
-        types: [  {title:"reset"},
-                  {title:"restaurant"},
-                  {title:"travel"},
-                  {title:"shopping"},
-                ],//spot種別一覧
-        featureIcons: {
-          restaurant: "mdi-silverware-fork-knife",
-          travel: "mdi-bag-suitcase",
-          shopping: "mdi-cart",
-          reset:"mdi-map-marker-circle"
-        },//iconたち
       };
     },
     methods: {
@@ -182,9 +94,6 @@ export default {
         //現在地マーカーを設置
         //this.map.on("locationfound",this.locationMarker);
       },
-      changeSearchType: async function(type){
-      this.nowType = type;
-      },
     },
     mounted: function() {
       //Mapオブジェクトの生成
@@ -227,8 +136,6 @@ body {
 }
   /* 各オブジェクトのstyleでz-indexを0以上に設定する 
   基本は1000でOK*/
-#map-reg,
-#now-loc,
 #v-list-item,
 #feature-menu,
 #feature-button,

--- a/front/src/components/Map/Map.vue
+++ b/front/src/components/Map/Map.vue
@@ -6,7 +6,7 @@
     <!-- 通常モードとスポット登録モードの切り替えボタン -->
     <spot-reg-button :regFlag="regFlag" v-on:click.native="changeMode()"/>
     <!-- 現在地ボタン -->
-    <now-loc-button v-on:click.native="nowLocation()"/>
+    <now-loc-button v-on:click.native="setNowLocation()"/>
   </div>
 </template>
 

--- a/front/src/components/Map/MapButtons/NowLocButton.vue
+++ b/front/src/components/Map/MapButtons/NowLocButton.vue
@@ -1,0 +1,29 @@
+<template>
+        
+<!-- 現在地ボタン -->
+<v-btn
+    id='now-loc'
+    absolute
+    class="mx-4 my-15"
+    right
+    bottom
+    fab
+    >
+    <v-icon
+      color="#5D8C99"
+      class="px-5"
+      large 
+        >
+        mdi-crosshairs-gps
+    </v-icon>
+</v-btn>
+
+</template>
+
+<style>
+
+#now-loc{
+  z-index: 1000;
+}
+
+</style>

--- a/front/src/components/Map/MapButtons/NowLocButton.vue
+++ b/front/src/components/Map/MapButtons/NowLocButton.vue
@@ -1,7 +1,7 @@
 <template>
         
-<!-- 現在地ボタン -->
-<v-btn
+  <!-- 現在地ボタン -->
+  <v-btn
     id='now-loc'
     absolute
     class="mx-4 my-15"
@@ -13,10 +13,10 @@
       color="#5D8C99"
       class="px-5"
       large 
-        >
-        mdi-crosshairs-gps
+      >
+      mdi-crosshairs-gps
     </v-icon>
-</v-btn>
+  </v-btn>
 
 </template>
 

--- a/front/src/components/Map/MapButtons/SpotRegButton.vue
+++ b/front/src/components/Map/MapButtons/SpotRegButton.vue
@@ -1,0 +1,45 @@
+<template>
+<!-- 通常モードとスポット登録モードの切り替えボタン -->
+<v-btn 
+      id='map-reg'
+      class="mx-4 my-5"
+      absolute
+      right
+      fab
+    >
+    <!-- 通常モードアイコン -->
+     <v-icon
+      v-if="!regFlag"
+      class="px-5"
+      large
+      >
+        mdi-earth
+     </v-icon>
+      <!-- 登録モードアイコン -->
+     <v-icon
+      v-if="regFlag"
+      class="px-5"
+      color="#CC1651"
+      large
+      >
+        mdi-map-marker-plus
+     </v-icon>
+</v-btn>
+</template>
+
+<script>
+
+export default {
+    components: {
+    },
+
+    props: ['regFlag']
+    
+}
+</script>
+
+<style>
+#map-reg{
+  z-index: 1000;
+}
+</style>

--- a/front/src/components/Map/MapButtons/SpotRegButton.vue
+++ b/front/src/components/Map/MapButtons/SpotRegButton.vue
@@ -1,30 +1,30 @@
 <template>
 <!-- 通常モードとスポット登録モードの切り替えボタン -->
-<v-btn 
-      id='map-reg'
-      class="mx-4 my-5"
-      absolute
-      right
-      fab
+  <v-btn 
+    id='map-reg'
+    class="mx-4 my-5"
+    absolute
+    right
+    fab
     >
     <!-- 通常モードアイコン -->
-     <v-icon
+    <v-icon
       v-if="!regFlag"
       class="px-5"
       large
       >
         mdi-earth
-     </v-icon>
-      <!-- 登録モードアイコン -->
-     <v-icon
+    </v-icon>
+    <!-- 登録モードアイコン -->
+    <v-icon
       v-if="regFlag"
       class="px-5"
       color="#CC1651"
       large
       >
         mdi-map-marker-plus
-     </v-icon>
-</v-btn>
+    </v-icon>
+  </v-btn>
 </template>
 
 <script>

--- a/front/src/components/Map/MapButtons/TypeButton.vue
+++ b/front/src/components/Map/MapButtons/TypeButton.vue
@@ -1,0 +1,80 @@
+<template>
+<!-- spot種別検索メニュー -->
+<v-menu
+      id='feature-menu'
+      class="mx-15 my-5"
+      bottom
+      offset-x
+    >
+    <!-- クリックするとメニューが表示する -->
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn
+        id='feature-button'
+        class="mx-15 my-5"
+        left
+        fab
+        v-bind="attrs"
+        v-on="on"
+      >
+
+      <!-- 現在の検索種別のアイコンを表示 -->
+      <v-icon
+      class="px-5"
+      large
+      >
+      {{featureIcons[nowType]}}
+     </v-icon>
+      </v-btn>
+      <!-- 検索メニュー -->
+      </template>
+        <v-list 
+        id='feature-list' 
+        absolute
+        >
+        <v-list-item
+          v-for="(type,index) in types"
+          :key="index"
+          link
+        >
+          <v-list-item-title
+          v-on:click="changeSearchType(type.title)"
+          >{{ type.title }}</v-list-item-title>
+        </v-list-item>
+      </v-list>
+</v-menu>
+</template>
+
+<script>
+export default {
+    data: function(){
+        return {
+        nowType:'reset',//スポット検索の種別
+        types: [  {title:"reset"},
+                  {title:"restaurant"},
+                  {title:"travel"},
+                  {title:"shopping"},
+                ],//spot種別一覧
+        featureIcons: {
+          restaurant: "mdi-silverware-fork-knife",
+          travel: "mdi-bag-suitcase",
+          shopping: "mdi-cart",
+          reset:"mdi-map-marker-circle"
+        },//iconたち
+        }
+    },
+    methods:{
+        changeSearchType: async function(type){
+            this.nowType = type;
+        },
+    }
+}
+</script>
+
+<style>
+#v-list-item,
+#feature-menu,
+#feature-button,
+#feature-list{
+  z-index: 1000;
+}
+</style>

--- a/front/src/components/Map/MapButtons/TypeButton.vue
+++ b/front/src/components/Map/MapButtons/TypeButton.vue
@@ -1,47 +1,48 @@
 <template>
 <!-- spot種別検索メニュー -->
-<v-menu
-      id='feature-menu'
-      class="mx-15 my-5"
-      bottom
-      offset-x
-    >
-    <!-- クリックするとメニューが表示する -->
-    <template v-slot:activator="{ on, attrs }">
-      <v-btn
-        id='feature-button'
+    <v-menu
+        id='feature-menu'
         class="mx-15 my-5"
-        left
-        fab
-        v-bind="attrs"
-        v-on="on"
-      >
+        bottom
+        offset-x
+        >
+        <!-- クリックするとメニューが表示する -->
+        <template v-slot:activator="{ on, attrs }">
+        <v-btn
+            id='feature-button'
+            class="mx-15 my-5"
+            left
+            fab
+            v-bind="attrs"
+            v-on="on"
+            >
 
-      <!-- 現在の検索種別のアイコンを表示 -->
-      <v-icon
-      class="px-5"
-      large
-      >
-      {{featureIcons[nowType]}}
-     </v-icon>
-      </v-btn>
-      <!-- 検索メニュー -->
-      </template>
+            <!-- 現在の検索種別のアイコンを表示 -->
+            <v-icon
+                class="px-5"
+                large
+                >
+                {{featureIcons[nowType]}}
+            </v-icon>
+        </v-btn>
+        </template>
+
+        <!-- 検索メニュー -->
         <v-list 
-        id='feature-list' 
-        absolute
-        >
-        <v-list-item
-          v-for="(type,index) in types"
-          :key="index"
-          link
-        >
-          <v-list-item-title
-          v-on:click="changeSearchType(type.title)"
-          >{{ type.title }}</v-list-item-title>
-        </v-list-item>
-      </v-list>
-</v-menu>
+            id='feature-list' 
+            absolute
+            >
+            <v-list-item
+                v-for="(type,index) in types"
+                :key="index"
+                link
+                >
+                <v-list-item-title
+                    v-on:click="changeSearchType(type.title)"
+                    >{{ type.title }}</v-list-item-title>
+            </v-list-item>
+        </v-list>
+    </v-menu>
 </template>
 
 <script>
@@ -66,6 +67,7 @@ export default {
         this.changeSearchType
     },
     methods:{
+        //選ばれたジャンルタイプをMapに送信
         changeSearchType(type){
             this.nowType = type;
             this.$emit('update-type',this.nowType);

--- a/front/src/components/Map/MapButtons/TypeButton.vue
+++ b/front/src/components/Map/MapButtons/TypeButton.vue
@@ -62,9 +62,13 @@ export default {
         },//iconたち
         }
     },
+    created(){
+        this.changeSearchType
+    },
     methods:{
-        changeSearchType: async function(type){
+        changeSearchType(type){
             this.nowType = type;
+            this.$emit('update-type',this.nowType);
         },
     }
 }

--- a/front/src/components/Signup/Signup.vue
+++ b/front/src/components/Signup/Signup.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script>
-import {register} from '../routes/userRequest'
+import {register} from '../../routes/userRequest'
 export default {
 
     data: function() {


### PR DESCRIPTION
### 【実装内容】
Map画面作成
  
### 【テスト手順】
0. 一応npm install
1. map画面に移動 (/map)
2. 画面が表示されていることを確認
3. spot登録モード確認
- 右上のボタンが地球マークで、map上の点をクリックしても何も起こらないことを確認
- 右上のボタンを押すとアイコンがスポット追加アイコンになることを確認
- その状態でマップ上の点を押すと/registerに遷移することを確認
4. ジャンル検索ボタンを確認
- コンソールログを開く
- 左上のボタンを押すと、ダイアログが表示され、選択肢が出ることを確認
- 選択肢を選ぶとボタンのアイコンがそれに対応したものに変わることを確認
- コンソールログにアイコンに対応する文字列が出力されていることを確認
- マップ上のマーカーをクリックすると、座標オブジェクトとその時のジャンルが出力されることを確認

### 【チェック事項】
- 画面表示
- 各ボタンの仕様
- コンソールログ
- 全体デザイン

### 積み残し事項(将来アップデート)
- 現在地マーカー設置
- ジャンルの複数選択(バックの方針とすり合わせて)

### 【関連issue】
#17 