### PR TITLE
Fixed bug where trim is called on undefined variable

### DIFF
--- a/back/src/route/userController.js
+++ b/back/src/route/userController.js
@@ -56,9 +56,9 @@ module.exports = class UserController{
 
     async editUser(req, res){
         const currentEmail = req.body.currentEmail;
-        const newEmail = req.body.newEmail;
+        const newEmail = utility.isEmpty(req.body.newEmail) ? '' : req.body.newEmail;
         const newPassword = req.body.newPassword;
-        const newUserName = req.body.newUserName;
+        const newUserName = utility.isEmpty(req.body.newUserName) ? '' : req.body.newUserName;
         let encryptedNewPassword;
         const reg = /^[A-Za-z0-9]{1}[A-Za-z0-9_.-]*@{1}[A-Za-z0-9_.-]{1,}\.[A-Za-z0-9]{1,}$/;
         if (utility.isEmpty(newEmail)) {


### PR DESCRIPTION
Bug fix in userController.  Assigning empty string value to email and username when the value is undefined. Before this commit, the app would crash on line 84 when calling trim(): return userSQL.editUser(currentEmail.trim(), newEmail.trim(), encryptedNewPassword, newUserName.trim()).then((result)=>{