### PR TITLE
Feature/9 user edit information

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,4 +37,4 @@ services:
     volumes: 
       - ./front:/app/front
     ports: 
-      - "8080:8081"
+      - "8080:8080"

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -12,4 +12,4 @@ RUN apk update && \
     apk add --no-cache nodejs npm && \
     npm install
 
-CMD ["npm","run", "serve"]
+

--- a/front/src/components/UserProfile/SpotListCard.vue
+++ b/front/src/components/UserProfile/SpotListCard.vue
@@ -62,7 +62,9 @@
         >
 
           <!-- サブカード -->
-          <v-card max-width="400" >
+          <v-card max-width="400" 
+            @click="spotInformationPage(index)"
+          >
             <!-- カード画像 -->
             <v-img
               :src="card.src"
@@ -125,14 +127,14 @@ export default {
       this.select = i
       this.spot = [];
       if(i==0){
-        this.GoodSpot()
+        this.GoodSpotSort()
       }else if(i==1){
-        this.CreatedSpot()
+        this.CreatedSpotSort()
       }else if(i==2){
         this.spot = this.spot_list
       }
     },
-    CreatedSpot: function () {  
+    CreatedSpotSort: function () { // 作ったスポットを表示する関数 
       let j = 0
       for (let i = 0; i < this.spot_list.length; i++){
         if (this.spot_list[i].user_id==this.user.user_id){
@@ -141,7 +143,7 @@ export default {
         }
       }
     },
-    GoodSpot: function () {  
+    GoodSpotSort: function () { // いいね！したスポットを表示する関数
       let j = 0
       for (let i = 0; i < this.spot_list.length; i++){
         for (let k = 0; k < this.spot_list[i].review.length; k++){
@@ -152,7 +154,12 @@ export default {
           }
         }
       }
-    }
+    },
+    spotInformationPage: function(value) { // spotのカードをクリックしたときに動く関数
+      console.log(this.spot_list[value].spotId) // Debug
+      this.$router.push({ path: 'spot', query: { "spotId": this.spot_list[value].spotId } })
+    },
+
   }
 
 };

--- a/front/src/components/UserProfile/UserEdit.vue
+++ b/front/src/components/UserProfile/UserEdit.vue
@@ -44,7 +44,7 @@
                             <!-- ユーザー名変更 -->
                             <v-text-field label="変更後のユーザー名"
                                 prepend-icon="mdi-human"
-                                v-model="model.username"
+                                v-model="model.edit_username"
                                 :rules="usernameRules"
                                 :counter="128"/>
                             
@@ -91,7 +91,7 @@
                                 />
                             <v-text-field label="変更後のメールアドレス"
                                 prepend-icon="mdi-email"
-                                v-model="model.email_edit" 
+                                v-model="model.edit_email" 
                                 :counter="128"
                                 :rules="emailRulesEdit"
                                 />
@@ -152,7 +152,7 @@
                                 v-bind:append-icon="showPasswordEdit ? 'mdi-eye' : 'mdi-eye-off'" 
                                 v-bind:type="showPasswordEdit ? 'text' : 'password'" 
                                 @click:append="showPasswordEdit = !showPasswordEdit"
-                                v-model="model.password_edit"
+                                v-model="model.edit_password"
                                 :counter="32"
                                 :rules="passwordRulesEdit"
                                 />
@@ -227,6 +227,7 @@
 </template>
 
 <script>
+import {editUser} from '../../routes/userRequest'
 export default {
     props: {
         user: null
@@ -279,26 +280,34 @@ export default {
             this.stepData[2].edit= false
             this.model= {
                 username : "",
-                username_edit : "",
+                edit_username : "",
                 email : "",
-                email_edit: "",
+                edit_email: "",
                 password : "",
-                password_edit : "",
+                edit_password : "",
                 edit: false,
             }
         },
         register: function() {
-            // 修正情報を登録する関数
-            if(this.check_database()) {
-                this.edit_account()
-                this.model.edit_username = this.stepData[0].edit
-                this.model.edit_email = this.stepData[1].edit
-                this.model.edit_password = this.stepData[2].edit
-                this.$emit('close',this.model) // 親コンポーネントへ変数を渡す処理
-            }
-            else {
-                console.log("(Debug)failed to send database")
-            }
+            // // 修正情報を登録する関数
+            // if(this.check_database()) {
+            //     this.edit_account()
+            //     this.model.edit_username = this.stepData[0].edit
+            //     this.model.edit_email = this.stepData[1].edit
+            //     this.model.edit_password = this.stepData[2].edit
+            //     this.$emit('close',this.model) // 親コンポーネントへ変数を渡す処理
+            // }
+            // else {
+            //     console.log("(Debug)failed to send database")
+            // }
+            console.log(this.model.email);
+            console.log(this.model.edit_email);
+            console.log(this.model.edit_password);
+            console.log(this.model.edit_username);
+            editUser(this.model.email,this.model.edit_email,this.model.edit_password,this.model.edit_username)
+                .then(res => {
+                    console.log(res)
+                });
         },
 
         check_database: function() {

--- a/front/src/components/UserProfile/UserEdit.vue
+++ b/front/src/components/UserProfile/UserEdit.vue
@@ -53,14 +53,14 @@
                     <v-card-actions>
                         <v-btn
                         color="primary"
-                        @click="nextPage(1)"
+                        @click="continuePage(1)"
                         >
                         Continue
                         </v-btn>
 
                         <v-btn 
                         text
-                        @click="NotChange(1)"
+                        @click="skipPage(1)"
                         >
                         Skip
                         </v-btn>
@@ -83,12 +83,7 @@
                         <v-form ref="loginFormEmail">
 
                             <!-- メールアドレス変更 -->
-                            <v-text-field label="現在のメールアドレスを入力"
-                                prepend-icon="mdi-email"
-                                v-model="model.email" 
-                                :counter="128"
-                                :rules="emailRules"
-                                />
+
                             <v-text-field label="変更後のメールアドレス"
                                 prepend-icon="mdi-email"
                                 v-model="model.edit_email" 
@@ -101,14 +96,14 @@
                     <v-card-actions>
                         <v-btn
                         color="primary"
-                        @click="nextPage(2)"
+                        @click="continuePage(2)"
                         >
                         Continue
                         </v-btn>
 
                         <v-btn 
                         text
-                        @click="NotChange(2)"
+                        @click="skipPage(2)"
                         >
                         Skip
                         </v-btn>
@@ -137,15 +132,6 @@
                         <v-form ref="loginForm">
 
                             <!-- パスワード変更-->
-                            <v-text-field label="現在のパスワードを入力"
-                                prepend-icon="mdi-lock" 
-                                v-bind:append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'" 
-                                v-bind:type="showPassword ? 'text' : 'password'" 
-                                @click:append="showPassword = !showPassword"
-                                v-model="model.password"
-                                :counter="32"
-                                :rules="passwordRules"
-                                />
 
                             <v-text-field label="変更後のパスワード"
                                 prepend-icon="mdi-lock" 
@@ -161,14 +147,14 @@
                     <v-card-actions>
                         <v-btn
                         color="primary"
-                        @click="nextPage(3)"
+                        @click="continuePage(3)"
                         >
                         Continue
                         </v-btn>
 
                         <v-btn 
                         text
-                        @click="NotChange(3)"
+                        @click="skipPage(3)"
                         >
                         Skip
                         </v-btn>
@@ -200,7 +186,7 @@
                     <v-card-actions>
                         <v-btn
                         color="primary"
-                        @click="register"
+                        @click="editUserInformation"
                         >
                         Edit
                         </v-btn>
@@ -236,34 +222,33 @@ export default {
         return {
             state: null, // 修正UIの状態(1~4で遷移)
             showDialog: true, // trueで修正UIを表示
-            model: {}, // UserProfile.vueに送る関数
-            showPassword : false, // trueで修正前パスワード表示
+            model: { // edit後の情報を書き込むclassです。
+                username : "",
+                edit_username : "",
+                email : "",
+                edit_email: "",
+                password : "",
+                edit_password : "",
+                edit: false,
+            },
+
             showPasswordEdit : false, // trueで修正後パスワード表示
             stepData: [ // 各ステップで使用する変数を格納する配列
                 { name: "Username", edit: false, form: "loginFormName"},
                 { name: "Email", edit: false, form: "loginFormEmail"},
                 { name: "Password", edit: false, form: "loginFormPassword"},
             ],
-
             // 以下、修正入力上のルール設定
-            usernameRules: [
+            usernameRules: [ // usernameの入力ルール
                 v => !!v || "ユーザ名は必須項目です。",
                 v => (v && v.length <= 32) || "ユーザ名は32文字以内で入力してください。",
             ],
-            emailRules: [
-                v => !!v || "メールアドレスは必須項目です。",
-                v => (v && v == this.user.mail) || "メールアドレスが違います。"
-            ],
-            emailRulesEdit: [
+            emailRulesEdit: [ // emailの入力ルール
                 v => !!v || "メールアドレスは必須項目です。",
                 v => (v && v.length <= 128) || "メールアドレスは128文字以内で入力してください。",
                 v => /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(v) || "メールアドレスの形式が正しくありません。"
             ],
-            passwordRules: [
-                v => !!v || "パスワードは必須項目です。",
-                v => (v && v == this.user.password) || "パスワードが違います。"
-            ],
-            passwordRulesEdit: [
+            passwordRulesEdit: [ // password の入力ルール
                 v => !!v || "パスワードは必須項目です。",
                 v => (v && v.length >= 8) || "パスワードは8文字以上で入力してください。",
                 v => (v && v.length <= 32) || "パスワードは32文字以内で入力してください。"
@@ -272,69 +257,45 @@ export default {
     },
 
     methods: {
-        initialState: function() {
-            // 初期化関数
-            this.showDialog= true
-            this.stepData[0].edit= false,
-            this.stepData[1].edit= false
-            this.stepData[2].edit= false
-            this.model= {
-                username : "",
-                edit_username : "",
-                email : "",
-                edit_email: "",
-                password : "",
-                edit_password : "",
-                edit: false,
+        editUserInformation: function() { // edit user information関数
+            if (this.model.edit_email == ""){
+                this.model.edit_email=this.user.email
             }
-        },
-        register: function() {
-            // // 修正情報を登録する関数
-            // if(this.check_database()) {
-            //     this.edit_account()
-            //     this.model.edit_username = this.stepData[0].edit
-            //     this.model.edit_email = this.stepData[1].edit
-            //     this.model.edit_password = this.stepData[2].edit
-            //     this.$emit('close',this.model) // 親コンポーネントへ変数を渡す処理
-            // }
-            // else {
-            //     console.log("(Debug)failed to send database")
-            // }
-            console.log(this.model.email);
-            console.log(this.model.edit_email);
-            console.log(this.model.edit_password);
-            console.log(this.model.edit_username);
-            editUser(this.model.email,this.model.edit_email,this.model.edit_password,this.model.edit_username)
+            if (this.model.edit_username == ""){
+                this.model.edit_username=this.user.username
+            }
+            if (this.model.edit_password == ""){
+                this.model.edit_password=this.user.password
+            }
+            // Debug //
+            console.log(this.user.email); // 変更前のemail
+            console.log(this.model.edit_email); // 変更後のemail
+            console.log(this.model.edit_password); // 変更後のpassword
+            console.log(this.model.edit_username); // 変更後のusername
+
+            // backendのデータの修正処理
+            editUser(this.user.email,this.model.edit_email,this.model.edit_password,this.model.edit_username)
                 .then(res => {
                     console.log(res)
+                    this.reLoad()
                 });
-        },
-
-        check_database: function() {
-            //TODO: アカウントを修正できるか確認
-            return true
-        },
-
-        edit_account: function() {
-            //TODO: アカウントを修正する処理
-            console.log("(Debug)edit_account")
-            
         },
 
         closeCard: function(){
             // 修正UIを閉じる関数
-            this.reLoad()
-            // this.$emit('close',this.model)
+            // this.reLoad()
+            this.showDialog = false
+            this.$emit('close')
 
         },
 
-        NotChange: function(value){
+        skipPage: function(value){
             // 修正をスキップする関数
             this.state = value+1
             this.stepData[value-1].edit = false
         },
 
-        nextPage: function(value){
+        continuePage: function(value){
             // 修正項目を入力した後に次のステップに遷移する関数
             if(value==1 && this.$refs.loginFormName.validate()){
                 this.stepData[value-1].edit = true
@@ -359,7 +320,7 @@ export default {
             this.state = value-1
         },
         reLoad: function () {
-        this.$router.go({path: this.$router.currentRoute.path, force: true})
+            this.$router.go({path: this.$router.currentRoute.path, force: true})
         }
         
     }

--- a/front/src/components/UserProfile/UserEdit.vue
+++ b/front/src/components/UserProfile/UserEdit.vue
@@ -260,12 +260,15 @@ export default {
         editUserInformation: function() { // edit user information関数
             if (this.model.edit_email == ""){
                 this.model.edit_email=this.user.email
+                // this.model.edit_email=undefined // TODO:undefinedを送ったらその情報は修正しないという処理用
             }
             if (this.model.edit_username == ""){
                 this.model.edit_username=this.user.username
+                // this.model.edit_username=undefined // TODO:undefinedを送ったらその情報は修正しないという処理用
             }
             if (this.model.edit_password == ""){
                 this.model.edit_password=this.user.password
+                // this.model.edit_password=undefined // TODO:undefinedを送ったらその情報は修正しないという処理用
             }
             // Debug //
             console.log(this.user.email); // 変更前のemail

--- a/front/src/components/UserProfile/UserProfile.vue
+++ b/front/src/components/UserProfile/UserProfile.vue
@@ -4,7 +4,7 @@
 <!-----------------------修正処理(修正ボタンを押すと起動)------------------------------------------------>
         <v-dialog v-model="dialogEdit" width=500>
             <UserEdit 
-                @close="FromUserEdit"
+                @close="closeUserEdit"
                 v-bind:user="user"
                 ref="child"
             >
@@ -22,7 +22,7 @@
 <!-----------------------ユーザー名とプロフィール修正ボタン------------------------->
             <v-col>
                 ユーザー名
-                <h1>{{ user.name }}</h1>
+                <h1>{{ user.username }}</h1>
                 
                     <v-spacer></v-spacer>
                     <v-btn
@@ -46,7 +46,7 @@
 
 import SpotListCard from "./SpotListCard.vue";
 import UserEdit from "./UserEdit.vue";
-
+import {getUser} from '../../routes/userRequest'
 
 export default {
 
@@ -59,10 +59,9 @@ export default {
             editer: false,
             dialogEdit: false,
             user: { // ユーザー仮データ
-                name: 'タカタ',
-                user_id: '000000',
-                mail: 'takata@takata.com',
-                password: 'takata',
+                username: '',
+                email: 'takata@takata.com',
+                password: '',
                 src: require('@/assets/pose_kuyashii_man.png')
             },
             spot: [ // spot仮データ
@@ -108,26 +107,22 @@ export default {
             ]
         }
     },
+    mounted: function(){
+        // call getUser(email) from .vue file:
+        getUser(this.user.email)
+            .then(result => {
+                console.log(result[0])
+                console.log(result[0].username)
+                this.user.username = result[0].username
+        })  
+    },
     methods:  {
         editProfile: function() {
             this.dialogEdit = true
         },
-        FromUserEdit: function(value){
-            // UserEdit.vueが起動する関数（修正完了時or修正キャンセル時）
-            if(value.edit_email==true){
-                this.user.mail=value.email_edit
-            }
-            if(value.edit_password == true){
-                this.user.password=value.password_edit
-            }
-            if(value.edit_username == true){
-                this.user.name=value.username
-            }      
-            console.log(this.user.name,this.user.mail,this.user.password)
-            
+        closeUserEdit: function(){          
             this.dialogEdit = false
-
-        }
+        },
     }
 };
 </script>

--- a/front/src/components/UserProfile/UserProfile.vue
+++ b/front/src/components/UserProfile/UserProfile.vue
@@ -61,7 +61,7 @@ export default {
             user: { // ユーザー仮データ
                 username: '',
                 email: 'takata@takata.com',
-                password: '',
+                password: 'takatakeisuke',
                 src: require('@/assets/pose_kuyashii_man.png')
             },
             spot: [ // spot仮データ
@@ -114,6 +114,7 @@ export default {
                 console.log(result[0])
                 console.log(result[0].username)
                 this.user.username = result[0].username
+                // this.user.password = result[0].password
         })  
     },
     methods:  {

--- a/front/src/components/UserProfile/UserProfile.vue
+++ b/front/src/components/UserProfile/UserProfile.vue
@@ -67,7 +67,7 @@ export default {
             spot: [ // spot仮データ
                 {
                     name: 'マクドナルド',
-                    id: '000000',
+                    spotId: '000000',
                     type: 'restaurant',
                     user_id: '000000',
                     username: 'asada',
@@ -80,7 +80,7 @@ export default {
                 },
                 {
                     name: 'モスバーガー',
-                    id: '000001',
+                    spotId: '000001',
                     type: 'restaurant',
                     username: 'takata',
                     user_id: '000001',
@@ -93,7 +93,7 @@ export default {
                 },      
                 {
                     name: 'KFC',
-                    id: '000002',
+                    spotId: '000002',
                     type: 'restaurant',
                     user_id: '000002',
                     username: 'matsuo',

--- a/front/src/routes/userRequest.js
+++ b/front/src/routes/userRequest.js
@@ -39,4 +39,24 @@ async function getUser(email){
     }
 }
 
-export {register,getUser};
+async function editUser(currentEmail,newEmail,newPassword,newUserName){
+    const url = serverIP + '/user/editUser';
+    try{
+        let reponse = await fetch(url,{
+            mode: 'cors',
+            method: 'PUT',
+            headers:{
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'Origin': 'http://localhost:8080'
+            },
+            body: JSON.stringify({currentEmail: currentEmail, newEmail: newEmail, newPassword: newPassword, newUserName: newUserName})
+        });
+        return await reponse.json();
+    }catch(exception){
+        console.log(exception);
+        return{success:false, data:exception};
+    }
+}
+
+export {register,getUser,editUser};


### PR DESCRIPTION
### 【実装内容】
ユーザープロフィールをeditする処理の追加
  
### 【テスト手順】
*現在のemail：takata@takata.com（コードの中に直接書き込んでいます）
# (注意) emailを変更するとバックエンドからデータを持ってこれなくなるので変更しないでください。
1. ユーザープロフィール画面に移動 (/user)
1.  ユーザー名は現在のバックエンド側にあるtakata@takata.comで登録されている名前になる。
1. 「EDIT」ボタンを押す
1. 修正用のUIが表示されるのを確認
1. 好きなユーザー名を入力
1. 「Continue」ボタンを押す
(入力ルールに反する場合は進まない)
1. email は「skip」ボタンで飛ばしてください(変更するとデータがとってこれなくなる)
1. 「パスワード」は変更してもしなくてもよいです
1. 最終的に3つの項目（「ユーザー名」,「メールアドレス」,「パスワード」）のステップを終えると、「本当に修正しますか？」と出てくるので「Edit」をクリック。
1. consoleに修正後の「現在のメールアドレス」「新しいメールアドレス(今回は現在のやつと一緒)」,「新しいパスワード」「新しいユーザー名」の4つが表示される（入力しなかった場合はデフォルトの値が表示される）
1. ページが更新される
＊ユーザー名を変更するとユーザー名の表示が変わります

1. 「×」ボタンを押すと修正UIが閉じる。

### 【関連issue】
#9 