### PR TITLE
improve build speed

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -32,7 +32,6 @@
     "eslint-plugin-vue": "^6.2.2",
     "sass": "^1.19.0",
     "sass-loader": "^8.0.0",
-    "vue-cli-plugin-vuetify": "~2.0.7",
     "vue-template-compiler": "^2.6.11",
     "vuetify-loader": "^1.3.0"
   },

--- a/front/src/main.js
+++ b/front/src/main.js
@@ -1,8 +1,10 @@
 import Vue from 'vue'
 import App from './App.vue'
-import vuetify from './plugins/vuetify';
 import router from './router'
 import store from './store'
+const vuetify = process.env.NODE_ENV === "production"
+  ? require('./plugins/vuetify').default
+  : require('./plugins/vuetify-dev').default;
 
 Vue.config.productionTip = false
 

--- a/front/src/plugins/vuetify-dev.js
+++ b/front/src/plugins/vuetify-dev.js
@@ -1,0 +1,7 @@
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+import 'vuetify/dist/vuetify.min.css';
+
+Vue.use(Vuetify);
+
+export default new Vuetify({});

--- a/front/vue.config.js
+++ b/front/vue.config.js
@@ -1,7 +1,14 @@
+const vuetifyOptional = process.env.NODE_ENV === "production"
+  ? [new (require('vuetify-loader/lib/plugin'))()]
+  : [];
+
 module.exports = {
-  "transpileDependencies": [
-    "vuetify"
-  ],
+  configureWebpack: {
+    plugins: [
+      ...vuetifyOptional,
+    ],
+  },
+  transpileDependencies: vuetifyOptional.length > 0 ? ["vuetify"] : [],
   devServer: {
     public: '0.0.0.0:8080'
   }


### PR DESCRIPTION
frontの`npm run serve`が遅すぎる問題を解決

### 導入手順
1. frontコンテナに入る
1. `npm install`を実行
1. いつも通り実行してみる