### PR TITLE
Get spot type function

### DIFF
--- a/front/src/components/Map/MapButtons/TypeButton.vue
+++ b/front/src/components/Map/MapButtons/TypeButton.vue
@@ -38,33 +38,30 @@
                 link
                 >
                 <v-list-item-title
-                    v-on:click="changeSearchType(type.title)"
-                    >{{ type.title }}</v-list-item-title>
+                    v-on:click="changeSearchType(type)"
+                    >{{ type }}</v-list-item-title>
             </v-list-item>
         </v-list>
     </v-menu>
 </template>
 
 <script>
+import {getSpotTypeData} from "../../share/SpotTypeFunction"
 export default {
     data: function(){
         return {
-        nowType:'reset',//スポット検索の種別
-        types: [  {title:"reset"},
-                  {title:"restaurant"},
-                  {title:"travel"},
-                  {title:"shopping"},
-                ],//spot種別一覧
-        featureIcons: {
-          restaurant: "mdi-silverware-fork-knife",
-          travel: "mdi-bag-suitcase",
-          shopping: "mdi-cart",
-          reset:"mdi-map-marker-circle"
-        },//iconたち
+            nowType:'reset',//スポット検索の種別
+            types:["reset"], //spot種別一覧
+            featureIcons: getSpotTypeData(), // iconたち
         }
     },
     created(){
         this.changeSearchType
+    },
+    mounted(){
+        let typeNameList = Object.keys(this.featureIcons) //spot type object のkey配列作成
+        this.types.push(... typeNameList ) // typesにtype name listを追加
+        this.$set(this.featureIcons, 'reset', "mdi-map-marker-circle") // iconオブジェクトにreset icon追加
     },
     methods:{
         //選ばれたジャンルタイプをMapに送信
@@ -72,6 +69,7 @@ export default {
             this.nowType = type;
             this.$emit('update-type',this.nowType);
         },
+        
     }
 }
 </script>

--- a/front/src/components/Map/MapButtons/TypeButton.vue
+++ b/front/src/components/Map/MapButtons/TypeButton.vue
@@ -51,8 +51,8 @@ export default {
     data: function(){
         return {
             nowType:'reset',//スポット検索の種別
-            types:["reset"], //spot種別一覧
-            featureIcons: getSpotTypeDict(), // iconたち
+            types:["reset"], //spot種別一覧を格納するlist -> mountedでデータ追加
+            featureIcons: getSpotTypeDict(), // iconを格納するオブジェクト -> mountedでデータ追加
         }
     },
     created(){

--- a/front/src/components/Map/MapButtons/TypeButton.vue
+++ b/front/src/components/Map/MapButtons/TypeButton.vue
@@ -52,15 +52,15 @@ export default {
         return {
             nowType:'reset',//スポット検索の種別
             types:["reset"], //spot種別一覧を格納するlist -> mountedでデータ追加
-            featureIcons: getSpotTypeDict(), // iconを格納するオブジェクト -> mountedでデータ追加
+            featureIcons: getSpotTypeDict('icon'), // iconを格納するオブジェクト -> mountedでデータ追加
+            typeNameList: getSpotTypeDict('type') //spot type object のkey配列作成 -> mountedで'reset'追加
         }
     },
     created(){
         this.changeSearchType
     },
     mounted(){
-        let typeNameList = Object.keys(this.featureIcons) //spot type object のkey配列作成
-        this.types.push(... typeNameList ) // typesにtype name listを追加
+        this.types.push(... this.typeNameList ) // typesにtype name listを追加
         this.$set(this.featureIcons, 'reset', "mdi-map-marker-circle") // iconオブジェクトにreset icon追加
     },
     methods:{

--- a/front/src/components/Map/MapButtons/TypeButton.vue
+++ b/front/src/components/Map/MapButtons/TypeButton.vue
@@ -46,13 +46,13 @@
 </template>
 
 <script>
-import {getSpotTypeData} from "../../share/SpotTypeFunction"
+import {getSpotTypeDict} from "../../share/SpotTypeFunction"
 export default {
     data: function(){
         return {
             nowType:'reset',//スポット検索の種別
             types:["reset"], //spot種別一覧
-            featureIcons: getSpotTypeData(), // iconたち
+            featureIcons: getSpotTypeDict(), // iconたち
         }
     },
     created(){

--- a/front/src/components/SpotDetail/SpotDetail.vue
+++ b/front/src/components/SpotDetail/SpotDetail.vue
@@ -22,11 +22,11 @@
                 <h1 class="mr-10"> {{ spot_data.name }} </h1>
 
                 <!-- スポットタイプ -->
-                <spot-type-icon v-for="type in spot_data.types" :key="type"
+                <spot-type-icon 
+                    v-for="type in spot_data.types" 
+                    :key="type"
                     :type="type"
-                    class="mr-5"
-                    large
-                    color="gray"
+                    iconColor="gray"
                 />
 
             </v-row>

--- a/front/src/components/SpotRegister/SpotRegister.vue
+++ b/front/src/components/SpotRegister/SpotRegister.vue
@@ -142,7 +142,7 @@ export default {
             //新しいタイプが追加されると他に書き換えるところが出てくる(SpotTypeIcon.vueなど)
             //スポットタイプ名のリストをどこかにまとめる方法はないか
             // =>解決
-            all_spot_types: {},
+            all_spot_types: {}, // mountedで取得
 
             // アップロードされたファイルを一時的に保管する変数
             // 適切な形式に変換された画像データをspot_data.photosに入れるために必要

--- a/front/src/components/SpotRegister/SpotRegister.vue
+++ b/front/src/components/SpotRegister/SpotRegister.vue
@@ -158,8 +158,7 @@ export default {
         }
     },
     mounted(){
-            let Data = getSpotTypeDict()
-            this.all_spot_types = Object.keys(Data)
+        this.all_spot_types = getSpotTypeDict('type')
     },
 
     methods: {

--- a/front/src/components/SpotRegister/SpotRegister.vue
+++ b/front/src/components/SpotRegister/SpotRegister.vue
@@ -116,7 +116,7 @@
 
 <script>
 import SpotTypeIcon from "../share/SpotTypeIcon.vue"
-import {getSpotTypeData} from "../share/SpotTypeFunction"
+import {getSpotTypeDict} from "../share/SpotTypeFunction"
 import {saveSpot} from '../../routes/spotRequest'
 import StarRating from 'vue-star-rating'
 
@@ -158,7 +158,7 @@ export default {
         }
     },
     mounted(){
-            let Data = getSpotTypeData()
+            let Data = getSpotTypeDict()
             this.all_spot_types = Object.keys(Data)
     },
 

--- a/front/src/components/SpotRegister/SpotRegister.vue
+++ b/front/src/components/SpotRegister/SpotRegister.vue
@@ -116,6 +116,7 @@
 
 <script>
 import SpotTypeIcon from "../share/SpotTypeIcon.vue"
+import {getSpotTypeData} from "../share/SpotTypeFunction"
 import {saveSpot} from '../../routes/spotRequest'
 import StarRating from 'vue-star-rating'
 
@@ -140,11 +141,8 @@ export default {
             //ここの記述があんまり良くない
             //新しいタイプが追加されると他に書き換えるところが出てくる(SpotTypeIcon.vueなど)
             //スポットタイプ名のリストをどこかにまとめる方法はないか
-            all_spot_types: [
-                "restaurant",
-                "travel",
-                "shopping"
-            ],
+            // =>解決
+            all_spot_types: {},
 
             // アップロードされたファイルを一時的に保管する変数
             // 適切な形式に変換された画像データをspot_data.photosに入れるために必要
@@ -158,6 +156,10 @@ export default {
             ]
 
         }
+    },
+    mounted(){
+            let Data = getSpotTypeData()
+            this.all_spot_types = Object.keys(Data)
     },
 
     methods: {
@@ -193,21 +195,21 @@ export default {
         ratingSelected: function (val) {
         this.$emit('rating-selected',val)
         },
-    currentRating: function (val) {
-        this.$emit('current-rating',val)}
-    },
+        currentRating: function (val) {
+            this.$emit('current-rating',val)}
+        },
 
-    watch: {
-        uploadedFiles: function() {
-            this.spot_data.photos = []
-            this.uploadedFiles.forEach(file => {
-                const reader = new FileReader()         //ファイルリーダを用意
-                reader.onload = (e) => {                //読み込みが完了したら配列に追加
-                    this.spot_data.photos.push(e.target.result)
-                }
-                reader.readAsDataURL(file)    
-            })
+        watch: {
+            uploadedFiles: function() {
+                this.spot_data.photos = []
+                this.uploadedFiles.forEach(file => {
+                    const reader = new FileReader()         //ファイルリーダを用意
+                    reader.onload = (e) => {                //読み込みが完了したら配列に追加
+                        this.spot_data.photos.push(e.target.result)
+                    }
+                    reader.readAsDataURL(file)    
+                })
+            }
         }
-    }
 }
 </script>

--- a/front/src/components/share/SpotTypeFunction.js
+++ b/front/src/components/share/SpotTypeFunction.js
@@ -1,10 +1,15 @@
-export function getSpotTypeDict() {
+export function getSpotTypeDict(value) {
     // spot type の追加や削除を一括で行うファイル
     var type_dict = {
         restaurant: "mdi-silverware-fork-knife",
         travel: "mdi-bag-suitcase",
         shopping: "mdi-cart"
-    }   
-    return type_dict;
+    }
+    var spot_types = Object.keys(type_dict)
+    if (value=='icon'){
+        return type_dict;
+    }else if(value=='type'){
+        return spot_types
+    }
 }
 

--- a/front/src/components/share/SpotTypeFunction.js
+++ b/front/src/components/share/SpotTypeFunction.js
@@ -1,0 +1,10 @@
+export function getSpotTypeData() {
+    // spot type の追加や削除を一括で行うファイル
+    var type_dict = {
+        restaurant: "mdi-silverware-fork-knife",
+        travel: "mdi-bag-suitcase",
+        shopping: "mdi-cart"
+    }   
+    return type_dict;
+}
+

--- a/front/src/components/share/SpotTypeFunction.js
+++ b/front/src/components/share/SpotTypeFunction.js
@@ -1,4 +1,4 @@
-export function getSpotTypeData() {
+export function getSpotTypeDict() {
     // spot type の追加や削除を一括で行うファイル
     var type_dict = {
         restaurant: "mdi-silverware-fork-knife",

--- a/front/src/components/share/SpotTypeIcon.vue
+++ b/front/src/components/share/SpotTypeIcon.vue
@@ -9,6 +9,7 @@
 </template>
 
 <script>
+import {getSpotTypeData} from "./SpotTypeFunction"
 export default {
     props: {
         type: String
@@ -16,11 +17,7 @@ export default {
 
     data: function() {
         return {
-            type_dict: {
-                restaurant: "mdi-silverware-fork-knife",
-                travel: "mdi-bag-suitcase",
-                shopping: "mdi-cart"
-            }
+            type_dict: getSpotTypeData()
         }
     }    
 }

--- a/front/src/components/share/SpotTypeIcon.vue
+++ b/front/src/components/share/SpotTypeIcon.vue
@@ -17,7 +17,7 @@ export default {
     },
     data: function() {
         return {
-            type_dict: getSpotTypeDict()
+            type_dict: getSpotTypeDict('icon')
         }
     }  
 }

--- a/front/src/components/share/SpotTypeIcon.vue
+++ b/front/src/components/share/SpotTypeIcon.vue
@@ -2,7 +2,7 @@
     <v-icon
         class="mr-5"
         large
-        color="gray"
+        :color="iconColor"
     >
         {{ type_dict[type] }}
     </v-icon>    
@@ -12,13 +12,13 @@
 import {getSpotTypeData} from "./SpotTypeFunction"
 export default {
     props: {
-        type: String
+        type: String,
+        iconColor: String // spot iconのカラー指定
     },
-
     data: function() {
         return {
             type_dict: getSpotTypeData()
         }
-    }    
+    }  
 }
 </script>

--- a/front/src/components/share/SpotTypeIcon.vue
+++ b/front/src/components/share/SpotTypeIcon.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-import {getSpotTypeData} from "./SpotTypeFunction"
+import {getSpotTypeDict} from "./SpotTypeFunction"
 export default {
     props: {
         type: String,
@@ -17,7 +17,7 @@ export default {
     },
     data: function() {
         return {
-            type_dict: getSpotTypeData()
+            type_dict: getSpotTypeDict()
         }
     }  
 }


### PR DESCRIPTION
### 【実装内容】
get spot type function作成
- 変更ファイル
    - Map/MapButtons/TypeButton.vue
    - Map/SpotRegister/SpotRegister.vue
    - Map/SpotDetail/SpotDetail.vue
    - Map/share/SpotTypeIcon.vue
- 作成ファイル
    - Map/share/SpotTypeFunction.js
### 【テスト手順】
1. /map画面が変わりないことを確認
1. /spot画面が変わりないことの確認
1. /register画面が変わりないことの確認

### 【関連issue】
#90 front_4