### PR TITLE
Image upload

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -15,4 +15,4 @@ COPY ./.env /app/.env
 
 EXPOSE 5000
 
-CMD ["npm","start"]
+#CMD ["npm","start"]

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -15,4 +15,4 @@ COPY ./.env /app/.env
 
 EXPOSE 5000
 
-#CMD ["npm","start"]
+CMD ["npm","start"]

--- a/back/package.json
+++ b/back/package.json
@@ -10,7 +10,8 @@
     "bcryptjs": "^2.4.3",
     "app-root-path": "3.0.0",
     "dotenv": "^8.2.0",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "multer": "1.4.2"
   },
   "devDependencies": {},
   "scripts": {

--- a/back/src/database/ImageSQL.js
+++ b/back/src/database/ImageSQL.js
@@ -83,7 +83,7 @@ async function uploadSpotPicture(newImage){
 
 async function getSpotPicture(spotId){
     const query = {
-        text: `SELECT * from images.spot where userid='${spotId}'`
+        text: `SELECT * from images.spot where spotid='${spotId}'`
     };
 
     const client = await pool.connect();

--- a/back/src/database/ImageSQL.js
+++ b/back/src/database/ImageSQL.js
@@ -1,0 +1,53 @@
+'use strict';
+const con = require('./DBHandler.js');
+const {info, debug, warning, error}  = require('../winston');
+const pool = con.pool;
+const fileLabel = "ImageSQL"
+
+
+async function uploadProfilePicture(newImage){
+    const query = {
+        text: 'INSERT INTO images.profile(userid, path) VALUES($1, $2)',
+        values: [newImage.userId, newImage.path]
+    };
+
+    const client = await pool.connect();
+    return client.query(query).then((result)=>{
+        client.release();
+        info(fileLabel,"Saved image: " + newImage.path);
+        return {"success":true};
+    }).catch((exception) => {
+        client.release();
+        error(fileLabel,"Error while saving image." + exception);
+        return {"success":false, "data":exception}; 
+    });
+}
+
+
+async function getProfilePicture(userId){
+    const query = {
+        text: `SELECT * from images.profile where userid=${userId}`
+    };
+
+    const client = await pool.connect();
+    return client.query(query).then((result)=>{
+        client.release();
+        if (result.rowCount == 0){
+            info(fileLabel,"Profile picture for this user does not exist");
+            return {"success":false};
+        }
+        else{
+            info(fileLabel,"Found image for user: " + userId);
+            return {"success":true, "data": result.rows};
+        }
+    }).catch((exception) => {
+        client.release();
+        error(fileLabel,"Error while getting image." + exception);
+        return {"success":false, "data":exception}; 
+    });
+}
+
+module.exports = {
+    uploadProfilePicture:uploadProfilePicture,
+    getProfilePicture: getProfilePicture
+};

--- a/back/src/database/ImageSQL.js
+++ b/back/src/database/ImageSQL.js
@@ -6,34 +6,26 @@ const fileLabel = "ImageSQL"
 
 
 async function uploadProfilePicture(newImage){
-    info(fileLabel,"Inside upload");
     var query;
     const client = await pool.connect();
     var userExist = await getProfilePicture(newImage.userId);
-    var oldPath;
     if (userExist.success){
         info(fileLabel,"User already exist. Updating picture");
         query = {
-            text: 'Update images.profile set path=$1 where userid=$2',
-            values: [newImage.path,newImage.userId]
+            text: 'Update images.profile set image=$1 where userid=$2',
+            values: [newImage.image,newImage.userId]
         };
-        //need old picture path to delete from filesystem
-        oldPath = userExist.data[userExist.data.length - 1].path
-
     } else{
-        info(fileLabel,"Inside else statement");
         query = {
-            text: 'INSERT INTO images.profile(userid, path) VALUES($1, $2)',
-            values: [newImage.userId, newImage.path]
+            text: 'INSERT INTO images.profile(userid, image) VALUES($1, $2)',
+            values: [newImage.userId, newImage.image]
         };
     }
-    console.log(query);
     return client.query(query).then((result)=>{
-        info(fileLabel,"Inside query");
         console.log(query);
         client.release();
-        info(fileLabel,"Saved image: " + newImage.path);
-        return {"success":true,"data":oldPath};
+        info(fileLabel,"Saved profile image");
+        return {"success":true};
     }).catch((exception) => {
         client.release();
         error(fileLabel,"Error while saving image." + exception);
@@ -65,7 +57,56 @@ async function getProfilePicture(userId){
     });
 }
 
+
+async function uploadSpotPicture(newImage){
+    var query;
+    const client = await pool.connect();
+
+    query = {
+        text: 'INSERT INTO images.spot(spotid, image) VALUES($1, $2)',
+        values: [newImage.spotId, newImage.image]
+    };
+
+    return client.query(query).then((result)=>{
+        info(fileLabel,"Inside query");
+        //console.log(query);
+        client.release();
+        info(fileLabel,"Saved spot image");
+        return {"success":true};
+    }).catch((exception) => {
+        client.release();
+        error(fileLabel,"Error while saving image." + exception);
+        return {"success":false, "data":exception}; 
+    });
+}
+
+
+async function getSpotPicture(spotId){
+    const query = {
+        text: `SELECT * from images.spot where userid='${spotId}'`
+    };
+
+    const client = await pool.connect();
+    return client.query(query).then((result)=>{
+        client.release();
+        if (result.rowCount == 0){
+            info(fileLabel,"There are no pictures for this spot");
+            return {"success":false};
+        }
+        else{
+            info(fileLabel,"Found image for spot: " + spotId);
+            return {"success":true, "data": result.rows};
+        }
+    }).catch((exception) => {
+        client.release();
+        error(fileLabel,"Error while getting image. " + exception);
+        return {"success":false, "data":exception}; 
+    });
+}
+
 module.exports = {
     uploadProfilePicture:uploadProfilePicture,
-    getProfilePicture: getProfilePicture
+    getProfilePicture: getProfilePicture,
+    uploadSpotPicture:uploadSpotPicture,
+    getSpotPicture:getSpotPicture
 };

--- a/back/src/route/imageRoute.js
+++ b/back/src/route/imageRoute.js
@@ -7,17 +7,17 @@ const {info, debug, warning, error}  = require('../winston');
 const imageSQL = require("../database/ImageSQL");
 const fileLabel = 'imageRoute'
 
-const storage = multer.diskStorage({
-    destination: (req, file, cb) => {
-      const path = `${process.cwd()}/src/uploads/`
-      fs.mkdirSync(path, { recursive: true })
-      return cb(null, path)
-    },
-    filename: (req, file, cb) => {
-        console.log(file);
-        cb(null, Date.now() + path.extname(file.originalname));
-    }
-});
+// const storage = multer.diskStorage({
+//     destination: (req, file, cb) => {
+//       const tempDir = `${process.cwd()}/src/uploads/`
+//       fs.mkdirSync(tempDir, { recursive: true })
+//       return cb(null, tempDir)
+//     },
+//     filename: (req, file, cb) => {
+//         console.log(file);
+//         cb(null, Date.now() + tempDir.extname(file.originalname));
+//     }
+// });
 
 const imageFilter = function(req, file, cb) {
     if (!file.originalname.match(/\.(jpg|JPG|jpeg|JPEG|png|PNG|gif|GIF)$/)) {
@@ -27,38 +27,103 @@ const imageFilter = function(req, file, cb) {
     cb(null, true);
 };
 
-const upload = multer({storage:storage, imageFilter:imageFilter});
+var store = multer.memoryStorage()
+var upload = multer({imageFilter:imageFilter});
 
 
-router.post("/spot-image", upload.single('file'), async function(req, res) {
+// function moveUploadedImage(uploadedImage,type){
+//     if (!type == "spots" && !type == "profile"){
+//         return console.error("Invalid image type");
+//     }
+
+//     const tempDir = `${process.cwd()}/src/uploads/`;
+//     const imgPath = path.join(tempDir,uploadedImage);
+
+//     const imgDir = path.join(tempDir,type+"/"); // $cwd/src/uploads/spots/ || $cwd/src/uploads/profile/
+//     fs.mkdirSync(imgDir, { recursive: true });
+//     const newImgPath = path.join(imgDir,uploadedImage);
+
+//     fs.move(imgPath, newImgPath, function (err) {
+//         if (err) {
+//             return console.error(err);
+//         }
+//     }  
+// }
+
+
+router.post("/spot-image/:spotId", upload.single('file'), async function(req, res) {
     console.log(req.file);
-    console.log(req.files);
-    //TODO
-    //add database call to store path
+    console.log(req.params);
+    var encoded_image = req.file.buffer.toString("base64");
+    var newImage = {spotId:req.params.spotId,image:encoded_image};
+    console.log(newImage.spotId);
 
-    return res.status(201).json({"success": true}); // success
+    return imageSQL.uploadSpotPicture(newImage).then((result) => {
+        if(result.success){            
+            return res.status(201).json({"success": true});
+        } else {
+            return res.status(400).json({"success": false});
+        }
+    }).catch((exception) => {
+        return res.status(400).json({"success": false, "error": exception});
+    });
+    
 });
 
-
+//Find out how to send back multiple files for one spot
 router.get("/spot-image/:spotId", async function(req,res){
     const spotId = req.params.spotId;
-    //if spot has many images, need to make a list and send all files
+
+    return imageSQL.getSpotPicture(spotId).then((result)=>{
+        if(result.success){
+            console.log(result);
+            info(fileLabel, "Fetched spot images successfully");
+            return res.status(200).sendFile(result.data[result.data.length - 1].path); //path to picture on filesystem
+        }else{
+            info(fileLabel, "Could not fetch profile image");
+            return res.status(400).json({"success": false});
+        }
+    }).catch((exception)=>{
+        error(fileLabel, "Error while getting profile image: " + exception )
+        return res.status(400).json({"success": false, "error": exception});
+    });
+
     res.sendFile();
 });
+
+
+// router.post("/profile-image/:userId", upload.single('file'), (req, res, cb) => {
+//     console.log(req.file);
+//     //console.log(req.files);
+//     var newImage = {userId:req.params.userId,path:req.file.path};
+//     console.log(newImage);
+//     return imageSQL.uploadProfilePicture(newImage).then((result) => {
+//         if(result.success){            
+//             if (result.data){
+//                 console.log("Previous path: " + result.data);
+//                 console.log("New path: " + newImage.path);
+//                 fs.unlinkSync(result.data);
+//             }
+//             return res.status(201).json({"success": true});
+//         } else {
+//             return res.status(400).json({"success": false});
+//         }
+//     }).catch((exception) => {
+//         return res.status(400).json({"success": false, "error": exception});
+//     });
+
+// });
 
 
 router.post("/profile-image/:userId", upload.single('file'), (req, res, cb) => {
     console.log(req.file);
     //console.log(req.files);
-    var newImage = {userId:req.params.userId,path:req.file.path};
+    var encoded_image = req.file.buffer.toString("base64");
+    var newImage = {userId:req.params.userId,image:encoded_image};
     console.log(newImage);
+
     return imageSQL.uploadProfilePicture(newImage).then((result) => {
         if(result.success){            
-            if (result.data){
-                console.log("Previous path: " + result.data);
-                console.log("New path: " + newImage.path);
-                fs.unlinkSync(result.data);
-            }
             return res.status(201).json({"success": true});
         } else {
             return res.status(400).json({"success": false});
@@ -68,7 +133,6 @@ router.post("/profile-image/:userId", upload.single('file'), (req, res, cb) => {
     });
 
 });
-
 
 router.get("/profile-image/:userId", async function(req, res){
     const userId = req.params.userId;
@@ -88,14 +152,4 @@ router.get("/profile-image/:userId", async function(req, res){
 });
 
 module.exports = router;
-
-
-
-    //For variable destination
-    //     var dir = JSON.parse(req.body.data).directory;
-    // var filename = req.file.filename;
-
-    // fs.move('../tempDir/' + fileName, '../tempDir/' + dir + '/' + fileName, function (err) {
-    //     if (err) {
-    //         return console.error(err);
-    //     }
+  

--- a/back/src/route/imageRoute.js
+++ b/back/src/route/imageRoute.js
@@ -1,0 +1,45 @@
+const express = require('express');
+const multer = require('multer');
+const router = express.Router();
+const path = require('path');
+const fs = require('fs');
+
+const storage = multer.diskStorage({
+    destination: (req, file, cb) => {
+      const path = `${process.cwd()}/src/uploads/`
+      fs.mkdirSync(path, { recursive: true })
+      return cb(null, path)
+    },
+    filename: (req, file, cb) => {
+        console.log(file);
+        cb(null, Date.now() + path.extname(file.originalname));
+    }
+});
+
+const imageFilter = function(req, file, cb) {
+    if (!file.originalname.match(/\.(jpg|JPG|jpeg|JPEG|png|PNG|gif|GIF)$/)) {
+        req.fileValidationError = 'Only image files are allowed!';
+        return cb(new Error('Only image files are allowed'), false);
+    }
+    cb(null, true);
+};
+
+const upload = multer({storage:storage, imageFilter:imageFilter});
+
+
+router.post("/spot-image", upload.single('file'), function(req, res) {
+    console.log(req.file);
+    console.log(req.files);
+
+    return res.status(201).json({"success": true}); // success
+    //For variable destination
+    //     var dir = JSON.parse(req.body.data).directory;
+    // var filename = req.file.filename;
+
+    // fs.move('../tempDir/' + fileName, '../tempDir/' + dir + '/' + fileName, function (err) {
+    //     if (err) {
+    //         return console.error(err);
+    //     }
+});
+
+module.exports = router;

--- a/back/src/route/imageRoute.js
+++ b/back/src/route/imageRoute.js
@@ -7,17 +7,6 @@ const {info, debug, warning, error}  = require('../winston');
 const imageSQL = require("../database/ImageSQL");
 const fileLabel = 'imageRoute'
 
-// const storage = multer.diskStorage({
-//     destination: (req, file, cb) => {
-//       const tempDir = `${process.cwd()}/src/uploads/`
-//       fs.mkdirSync(tempDir, { recursive: true })
-//       return cb(null, tempDir)
-//     },
-//     filename: (req, file, cb) => {
-//         console.log(file);
-//         cb(null, Date.now() + tempDir.extname(file.originalname));
-//     }
-// });
 
 const imageFilter = function(req, file, cb) {
     if (!file.originalname.match(/\.(jpg|JPG|jpeg|JPEG|png|PNG|gif|GIF)$/)) {
@@ -29,26 +18,6 @@ const imageFilter = function(req, file, cb) {
 
 var store = multer.memoryStorage()
 var upload = multer({imageFilter:imageFilter});
-
-
-// function moveUploadedImage(uploadedImage,type){
-//     if (!type == "spots" && !type == "profile"){
-//         return console.error("Invalid image type");
-//     }
-
-//     const tempDir = `${process.cwd()}/src/uploads/`;
-//     const imgPath = path.join(tempDir,uploadedImage);
-
-//     const imgDir = path.join(tempDir,type+"/"); // $cwd/src/uploads/spots/ || $cwd/src/uploads/profile/
-//     fs.mkdirSync(imgDir, { recursive: true });
-//     const newImgPath = path.join(imgDir,uploadedImage);
-
-//     fs.move(imgPath, newImgPath, function (err) {
-//         if (err) {
-//             return console.error(err);
-//         }
-//     }  
-// }
 
 
 router.post("/spot-image/:spotId", upload.single('file'), async function(req, res) {
@@ -70,7 +39,7 @@ router.post("/spot-image/:spotId", upload.single('file'), async function(req, re
     
 });
 
-//Find out how to send back multiple files for one spot
+
 router.get("/spot-image/:spotId", async function(req,res){
     const spotId = req.params.spotId;
 
@@ -78,7 +47,7 @@ router.get("/spot-image/:spotId", async function(req,res){
         if(result.success){
             console.log(result);
             info(fileLabel, "Fetched spot images successfully");
-            return res.status(200).sendFile(result.data[result.data.length - 1].path); //path to picture on filesystem
+            return res.status(200).json({"data":result.data}); //result.data is all the rows with corresponding spotId
         }else{
             info(fileLabel, "Could not fetch profile image");
             return res.status(400).json({"success": false});
@@ -87,32 +56,7 @@ router.get("/spot-image/:spotId", async function(req,res){
         error(fileLabel, "Error while getting profile image: " + exception )
         return res.status(400).json({"success": false, "error": exception});
     });
-
-    res.sendFile();
 });
-
-
-// router.post("/profile-image/:userId", upload.single('file'), (req, res, cb) => {
-//     console.log(req.file);
-//     //console.log(req.files);
-//     var newImage = {userId:req.params.userId,path:req.file.path};
-//     console.log(newImage);
-//     return imageSQL.uploadProfilePicture(newImage).then((result) => {
-//         if(result.success){            
-//             if (result.data){
-//                 console.log("Previous path: " + result.data);
-//                 console.log("New path: " + newImage.path);
-//                 fs.unlinkSync(result.data);
-//             }
-//             return res.status(201).json({"success": true});
-//         } else {
-//             return res.status(400).json({"success": false});
-//         }
-//     }).catch((exception) => {
-//         return res.status(400).json({"success": false, "error": exception});
-//     });
-
-// });
 
 
 router.post("/profile-image/:userId", upload.single('file'), (req, res, cb) => {
@@ -140,7 +84,8 @@ router.get("/profile-image/:userId", async function(req, res){
         if(result.success){
             console.log(result);
             info(fileLabel, "Fetched profile image successfully");
-            return res.status(200).sendFile(result.data[result.data.length - 1].path); //path to picture on filesystem
+            //var buffer = Buffer.from(result.data.image)
+            return res.status(200).json({image:result.data});
         }else{
             info(fileLabel, "Could not fetch profile image");
             return res.status(400).json({"success": false});

--- a/back/src/route/imageRoute.js
+++ b/back/src/route/imageRoute.js
@@ -3,6 +3,9 @@ const multer = require('multer');
 const router = express.Router();
 const path = require('path');
 const fs = require('fs');
+const {info, debug, warning, error}  = require('../winston');
+const imageSQL = require("../database/ImageSQL");
+const fileLabel = 'imageRoute'
 
 const storage = multer.diskStorage({
     destination: (req, file, cb) => {
@@ -27,11 +30,67 @@ const imageFilter = function(req, file, cb) {
 const upload = multer({storage:storage, imageFilter:imageFilter});
 
 
-router.post("/spot-image", upload.single('file'), function(req, res) {
+router.post("/spot-image", upload.single('file'), async function(req, res) {
     console.log(req.file);
     console.log(req.files);
+    //TODO
+    //add database call to store path
 
     return res.status(201).json({"success": true}); // success
+});
+
+
+router.get("/spot-image/:spotId", async function(req,res){
+    const spotId = req.params.spotId;
+    //if spot has many images, need to make a list and send all files
+    res.sendFile();
+});
+
+
+router.post("/profile-image/:userId", upload.single('file'), (req, res, cb) => {
+    console.log(req.file);
+    //console.log(req.files);
+    var newImage = {userId:req.params.userId,path:req.file.path};
+    console.log(newImage);
+    return imageSQL.uploadProfilePicture(newImage).then((result) => {
+        if(result.success){            
+            if (result.data){
+                console.log("Previous path: " + result.data);
+                console.log("New path: " + newImage.path);
+                fs.unlinkSync(result.data);
+            }
+            return res.status(201).json({"success": true});
+        } else {
+            return res.status(400).json({"success": false});
+        }
+    }).catch((exception) => {
+        return res.status(400).json({"success": false, "error": exception});
+    });
+
+});
+
+
+router.get("/profile-image/:userId", async function(req, res){
+    const userId = req.params.userId;
+    return imageSQL.getProfilePicture(userId).then((result)=>{
+        if(result.success){
+            console.log(result);
+            info(fileLabel, "Fetched profile image successfully");
+            return res.status(200).sendFile(result.data[result.data.length - 1].path); //path to picture on filesystem
+        }else{
+            info(fileLabel, "Could not fetch profile image");
+            return res.status(400).json({"success": false});
+        }
+    }).catch((exception)=>{
+        error(fileLabel, "Error while getting profile image: " + exception )
+        return res.status(400).json({"success": false, "error": exception});
+    });
+});
+
+module.exports = router;
+
+
+
     //For variable destination
     //     var dir = JSON.parse(req.body.data).directory;
     // var filename = req.file.filename;
@@ -40,6 +99,3 @@ router.post("/spot-image", upload.single('file'), function(req, res) {
     //     if (err) {
     //         return console.error(err);
     //     }
-});
-
-module.exports = router;

--- a/back/src/server.js
+++ b/back/src/server.js
@@ -8,6 +8,7 @@ const userRoute = require('./route/userRoute');
 const spotRoute = require('./route/spotRoute');
 const reviewRoute = require('./route/reviewRoute');
 const loginRoute = require('./route/loginRoute');
+const imageRoute = require('./route/imageRoute')
 
 app.use(cors())
 
@@ -16,6 +17,7 @@ app.use('/user',userRoute)
 app.use('/spot',spotRoute)
 app.use('/review',reviewRoute)
 app.use('/login',loginRoute)
+app.use('/upload',imageRoute)
 
 app.get('/', (req, res) => {
   console.log(req);


### PR DESCRIPTION
Images are now stored only in the database (no more local files in docker container)
Modified database fields to accept base64 encoded strings

- ImageRoute get requests now returns base64 encoded strings of images instead of binary image files. These string will have to be decoded  in the frontend before displaying them.

- Post request behaviour has not changed from previously (accepts binary image file). Only the behaviour in the backend has changed (images are now encoded before being stored)

Spot get request now returns list of all images corresponding to spotId

Postman requests to test:
GET
Spot:  http://localhost:5000/upload/spot-image/12345
Profile: http://localhost:5000/upload/profile-image/12345

POST (Must include file in body. See picture in comment below)
Spot: http://localhost:5000/upload/spot-image/12345
Profile: http://localhost:5000/upload/profile-image/12345
