### PR TITLE
make university search box

### DIFF
--- a/front/src/components/Signup/Signup.vue
+++ b/front/src/components/Signup/Signup.vue
@@ -27,20 +27,52 @@
                     :counter="32"
                     :rules="passwordRules" />
 
-                <v-select 
+                <v-autocomplete
                     label="所属大学"
+                    clearable
+                    value="univSearch"
                     v-model="university"
                     prepend-icon="mdi-school"
                     item-text="university"
-                    :items="universities"/>
+                    :items="universities"
+                    v-if='!this.isEditing'>
+
+                    <template v-slot:append-outer>
+                    <v-slide-x-reverse-transition
+                        mode="out-in"
+                    >
+                    <v-icon
+                        :key="`icon-${isEditing}`"
+                        :color="isEditing ? 'success' : 'info'"
+                        @click="isEditing = !isEditing"
+                    >
+                    mdi-pencil-plus
+                    </v-icon>
+                    </v-slide-x-reverse-transition>
+                    </template>
+                </v-autocomplete>
                 
                 <v-text-field label="所属大学を入力してください"
-                    v-model="addedUniversity" 
+                    v-model="university"
                     prepend-icon="mdi-fountain-pen-tip"
                     :counter="64"
                     :rules="universityRules"
-                    v-if='this.university == "その他"'/>
-
+                    v-if='this.isEditing'>
+                    <template v-slot:append-outer>
+                    <v-slide-x-reverse-transition
+                        mode="out-in"
+                    >
+                    <v-icon
+                        :key="`icon-${isEditing}`"
+                        color="red"
+                        @click="isEditing = !isEditing"
+                    >
+                    mdi-undo-variant
+                    </v-icon>
+                    </v-slide-x-reverse-transition>
+                    </template>
+                </v-text-field>
+                
                 <v-card-actions>
                     <v-btn @click="createUser">登録</v-btn>
                 </v-card-actions>
@@ -51,6 +83,13 @@
 </template>
 
 <script>
+/*
+import Vue from 'vue'
+import vSelect from 'vue-select'
+import 'vue-select/dist/vue-select.css'; 
+Vue.component('v-select', vSelect);
+*/
+
 import {register} from '../../routes/userRequest'
 import {getAllUniversities} from '../../routes/userRequest'
 const User = require("../../store/user");
@@ -63,6 +102,8 @@ export default {
             password : '',
             university: '',
             addedUniversity: '',
+            univSearch: '',
+            isEditing: false,
 
             showPassword : false,
             usernameRules: [
@@ -98,8 +139,6 @@ export default {
     methods: {
         createUser: function() {
             if (!this.$refs.loginForm.validate()) return;
-            if (this.university == "その他")
-                this.university = this.addedUniversity
             register(this.username,this.email,this.password,this.university)
                 .then(res => {
                     console.log(res)
@@ -110,7 +149,7 @@ export default {
                     this.$router.push('/map')
                 });
         },
-    }
+    },
     
 }
 </script>


### PR DESCRIPTION
## 実装
- ユーザ登録時に大学を逐次検索できるように変更
- 大学選択ボックスの隣に，新たな大学を追加するためのボタン追加

## テスト
- sign up ボタンをクリック
- 所属大学ボックスをクリックしたら大学リストが出ることを確認
- 所属大学ボックスに文字を入力して，入力した文字を含む大学のみがリスト化されることを確認
- 所属大学ボックスの右の鉛筆ボタンをクリックして，新たに追加する大学名が入力ができることを確認
- 所属大学ボックスの右の戻るボタンをクリックして大学リストボックスに戻れるか確認
- 正しくユーザ登録ができるか確認

## 関連issue
#157
