### PR TITLE
#172 マップのキーワード検索のUI変更

### DIFF
--- a/front/src/components/Map/Map.js
+++ b/front/src/components/Map/Map.js
@@ -30,6 +30,7 @@ export default {
             map: L.map,//Mapオブジェクト
             zoom:10,//zoomのサイズ まだうまく制御できてない(SATD)
             spot:null,//spot用のオブジェクト
+            spots:[],//スポット名のリスト，v-autocompleteで利用するため
             review:null,//review用のオブジェクト
             myplace:null,//現在地オブジェクト
             regFlag:false,//スポット登録モードのフラグ
@@ -176,6 +177,8 @@ export default {
         //this.map.on("locationfound",this.locationMarker);
         //spot表示
         this.showSpot(this.nowType,"","");
+        var data = await getSpot("","","","","");
+        this.spots = data.spots;
     }, 
     //現在地追跡のために利用(予定)
     watch: {

--- a/front/src/components/Map/Map.js
+++ b/front/src/components/Map/Map.js
@@ -30,7 +30,7 @@ export default {
             map: L.map,//Mapオブジェクト
             zoom:10,//zoomのサイズ まだうまく制御できてない(SATD)
             spot:null,//spot用のオブジェクト
-            spots:[],//スポット名のリスト，v-autocompleteで利用するため
+            spotNameList:[],//スポット名のリスト，v-autocompleteで利用するため
             review:null,//review用のオブジェクト
             myplace:null,//現在地オブジェクト
             regFlag:false,//スポット登録モードのフラグ
@@ -178,7 +178,7 @@ export default {
         //spot表示
         this.showSpot(this.nowType,"","");
         var data = await getSpot("","","","","");
-        this.spots = data.spots;
+        this.spotNameList = data.spots;
     }, 
     //現在地追跡のために利用(予定)
     watch: {

--- a/front/src/components/Map/Map.vue
+++ b/front/src/components/Map/Map.vue
@@ -2,7 +2,7 @@
 <!-- mapレイヤのような形で生成される -->
     <div id='map'>
         <!-- 検索ダイアログー -->
-        <search-dialog :spots="spots" @search="search" />
+        <search-dialog :spotNameList="spotNameList" @search="search" />
         <!-- 通常モードとスポット登録モードの切り替えボタン -->
         <spot-reg-button :regFlag="regFlag" v-on:click.native="changeMode()" v-if='this.$store.state.userData != null'/>
         <!-- 現在地ボタン -->

--- a/front/src/components/Map/Map.vue
+++ b/front/src/components/Map/Map.vue
@@ -2,7 +2,7 @@
 <!-- mapレイヤのような形で生成される -->
     <div id='map'>
         <!-- 検索ダイアログー -->
-        <search-dialog @search="search" />
+        <search-dialog :spots="spots" @search="search" />
         <!-- 通常モードとスポット登録モードの切り替えボタン -->
         <spot-reg-button :regFlag="regFlag" v-on:click.native="changeMode()" v-if='this.$store.state.userData != null'/>
         <!-- 現在地ボタン -->

--- a/front/src/components/Map/MapButtons/SearchDialog.vue
+++ b/front/src/components/Map/MapButtons/SearchDialog.vue
@@ -63,11 +63,18 @@
     </v-container>
     <!-- キーワード検索 -->
     <v-container>
-      <v-text-field label="検索ワード"
-      prepend-icon="mdi-alpha-a"
-      v-model="keyword"
-      />
+    <v-autocomplete
+        label="検索ワード"
+        clearable
+        single-line
+        v-model="keyword"
+        prepend-icon="mdi-alpha-a"
+        item-text="spot_name"
+        :items="spots">
+      </v-autocomplete>
+
     </v-container>
+
     <v-card-actions>
       <v-btn @click="Search(); dialog=false">
         <v-icon>
@@ -98,6 +105,7 @@ export default {
   components: {
     //typeButton
     },
+  props:['spots'],//スポット一覧
 
     created(){
       this.changeSearchType
@@ -105,9 +113,8 @@ export default {
     mounted(){
         this.types.push(... this.typeNameList ) // typesにtype name listを追加
         this.$set(this.featureIcons, 'reset', "mdi-map-marker-circle") // iconオブジェクトにreset icon追加
+        console.log(this.spots);
     },
-
-    //props: ['regFlag']
     methods:{
       Search(){
         //選ばれた検索条件をMapに送信

--- a/front/src/components/Map/MapButtons/SearchDialog.vue
+++ b/front/src/components/Map/MapButtons/SearchDialog.vue
@@ -70,7 +70,7 @@
         v-model="keyword"
         prepend-icon="mdi-alpha-a"
         item-text="spot_name"
-        :items="spots">
+        :items="spotNameList">
       </v-autocomplete>
 
     </v-container>
@@ -105,7 +105,7 @@ export default {
   components: {
     //typeButton
     },
-  props:['spots'],//スポット一覧
+  props:['spotNameList'],//スポット一覧
 
     created(){
       this.changeSearchType
@@ -113,7 +113,6 @@ export default {
     mounted(){
         this.types.push(... this.typeNameList ) // typesにtype name listを追加
         this.$set(this.featureIcons, 'reset', "mdi-map-marker-circle") // iconオブジェクトにreset icon追加
-        console.log(this.spots);
     },
     methods:{
       Search(){

--- a/front/src/components/Signup/Signup.vue
+++ b/front/src/components/Signup/Signup.vue
@@ -30,7 +30,6 @@
                 <v-autocomplete
                     label="所属大学"
                     clearable
-                    value="univSearch"
                     v-model="university"
                     prepend-icon="mdi-school"
                     item-text="university"
@@ -102,7 +101,6 @@ export default {
             password : '',
             university: '',
             addedUniversity: '',
-            univSearch: '',
             isEditing: false,
 
             showPassword : false,


### PR DESCRIPTION
### 【実装内容】
マップのキーワード検索にて，検索文字列を途中まで打つと，スポットの候補がいくつか表示されるように実装変更．
### 【テスト手順】
1. map上の左上のボタンを押して，検索フォームを開く
2. 検索フォームのキーワード検索欄に"a"を入力したとき，英語の"a"を含むものの候補が表示されることを確認
3. 表示されて選択肢を一つ選ぶと，フォームにその値が入力されるかをチェック
4. いくつか別のキーワードでも実行

### 【関連issue】
#172 