### PR TITLE
#133 詳細検索フォームの導入&スコア閾値の設定フォーム導入

### DIFF
--- a/front/src/components/Map/Map.js
+++ b/front/src/components/Map/Map.js
@@ -52,23 +52,26 @@ export default {
     },
     methods: {
         //Map上に検索条件にあったスポットを表示する関数
-        showSpot: async function(type,univ,keyword){
+        showSpot: async function(type,univ,keyword,rating){
             if (type=="reset") type = "";
             var data = await getSpot("","",type,"",univ);
             if (data.success){
-                var spots = data.spots;      
+                var spots = data.spots;
+                var review = data.review;  
                 //キーワードを含まないスポットを除外
                 spots = spots.filter(function(spot){
-                  return spot.spot_name.indexOf(keyword) != -1
+                    return spot.spot_name.indexOf(keyword) != -1;
                 });
                 var markerSet = []//マーカーのリスト
                 spots.forEach(spot => {
+                    if(this.culSpotRating(spot.spot_id,review) > rating){
                     var marker =  L.marker([spot.y, spot.x]).on('click', this.markerClickEvent);
                     marker.spot_name = spot.spot_name;
                     marker.spot_id = spot.spot_id;
                     marker.spot_type = spot.spot_type;
                     marker.spot_picture = spot.spot_picture;
                     markerSet.push(marker)
+                    }
                 });
                 this.markers = L.layerGroup(markerSet).addTo(this.map)
             } else {
@@ -138,15 +141,29 @@ export default {
 
         //検索ジャンルを更新するメソッド
         search: async function(...args){
-            const [type,univ,keyword] = args
+            const [type,univ,keyword,rating] = args
             this.markers.clearLayers();
             this.marker = [];
-            this.nowType = type;
+            this.nowType = type;    
+
             if(univ){
-                await this.showSpot(type,this.user.univ,keyword);
+                await this.showSpot(type,this.user.univ,keyword,rating);
             } else{
-                await this.showSpot(type,"",keyword);
+                await this.showSpot(type,"",keyword,rating);
             }
+        },
+        //スポットごとのレビュー評価平均を計算する関数
+        culSpotRating: function(spot_id,reviews){
+            reviews = reviews.filter(function(review){
+                return review.spot_id == spot_id
+              });
+            var sumRate=0;
+            var dataNum=0;
+            reviews.forEach(review => {
+                sumRate = sumRate+review.score;
+                dataNum += 1;
+            });
+            return sumRate/dataNum;
         },
         closeDialog() {
             this.showDialog = false;
@@ -176,7 +193,7 @@ export default {
         //現在地マーカーを設置(予定)
         //this.map.on("locationfound",this.locationMarker);
         //spot表示
-        this.showSpot(this.nowType,"","");
+        this.showSpot(this.nowType,"","",0);
         var data = await getSpot("","","","","");
         this.spotNameList = data.spots;
     }, 

--- a/front/src/components/Map/MapButtons/SearchDialog.vue
+++ b/front/src/components/Map/MapButtons/SearchDialog.vue
@@ -99,6 +99,7 @@
                 <!-- 大学別検索 -->
                 <v-container>
                     <v-btn-toggle
+                    v-if="userLogin!=null"
                     v-model="nowUniv"
                     group
                     mandatory
@@ -145,6 +146,7 @@ export default {
       keyword:"",//検索キーワード
       moreDetail:false,//詳細検索フォームの表示管理フラグ
       rating:0,//評価の閾値
+      userLogin: this.$store.state.userData,
     }
   },
   components: {

--- a/front/src/components/Map/MapButtons/SearchDialog.vue
+++ b/front/src/components/Map/MapButtons/SearchDialog.vue
@@ -1,93 +1,136 @@
 <template>
-  <!-- 検索ダイアログ -->
-  <v-dialog 
-  v-model="dialog"
-  width="500"
-  >
-  <template v-slot:activator="{ on,attrs }">
-  <!--ダイアログ呼び出しのボタン-->
-  <v-btn
-  id="search-button"
-  class="mx-15 my-5"
-  fab
-  v-bind="attrs"
-  v-on="on"
-  >
-    <v-icon
-      class="px-5"
-      large
-      >
-      mdi-card-search-outline
-    </v-icon>
-  </v-btn>
-  </template>
-  <!-- ダイアログの中身 -->
-  <v-card>
-    <!-- スポットタイプ検索 -->
-    <v-container>
-      <v-btn-toggle
-        v-model="nowType"
-        group
-        mandatory
-      >
-        <v-btn
-          v-for="type in types"
-          :key="type" 
-          :value="type" class="mx-auto" fab >
-          <v-icon>
-            {{featureIcons[type]}}
-          </v-icon>
-        </v-btn>
-      </v-btn-toggle>
-    </v-container>
-    <v-container>
-    
-    <!-- 大学別検索 -->
-    <v-btn-toggle
-      v-model="nowUniv"
-      group
-      mandatory
-      >
-        <v-btn value="false" class="mx-auto" fab >
-          <v-icon>
-            mdi-alpha-a-circle-outline
-          </v-icon>
-        </v-btn>
-        <v-btn value="true" class="mx-auto" fab >
-          <v-icon>
-            mdi-account-cowboy-hat
-          </v-icon>
-        </v-btn>
-    </v-btn-toggle>
-    
-    </v-container>
-    <!-- キーワード検索 -->
-    <v-container>
-    <v-autocomplete
-        label="検索ワード"
-        clearable
-        single-line
-        v-model="keyword"
-        prepend-icon="mdi-alpha-a"
-        item-text="spot_name"
-        :items="spotNameList">
-      </v-autocomplete>
+    <!-- 検索ダイアログ -->
+    <v-dialog 
+    v-model="dialog"
+    width="500"
+    >
+    <template v-slot:activator="{ on,attrs }">
 
-    </v-container>
-
-    <v-card-actions>
-      <v-btn @click="Search(); dialog=false">
-        <v-icon>
-        mdi-card-search
+    <!--ダイアログ呼び出しのボタン-->
+    <v-btn
+    id="search-button"
+    class="mx-15 my-5"
+    fab
+    v-bind="attrs"
+    v-on="on"
+    >
+        <v-icon
+        class="px-5"
+        large
+        >
+        mdi-card-search-outline
         </v-icon>
-      </v-btn> 
-    </v-card-actions>
+    </v-btn>
+    </template>
+    <!-- ダイアログの中身 -->
+    <v-card>
+        <!-- スポットタイプ検索 -->
+        <v-container>
+            <v-btn-toggle
+            v-model="nowType"
+            group
+            mandatory
+            >
+                <v-btn
+                v-for="type in types"
+                :key="type" 
+                :value="type" class="mx-auto" fab >
+                    <v-icon>
+                    {{featureIcons[type]}}
+                  </v-icon>
+                </v-btn>
+            </v-btn-toggle>
+        </v-container>
+
+        <!-- キーワード検索 -->
+        <v-container>
+        <v-autocomplete
+            label="検索ワード"
+            clearable
+            single-line
+            v-model="keyword"
+            prepend-icon="mdi-alpha-a"
+            item-text="spot_name"
+            :items="spotNameList">
+          </v-autocomplete>
+        </v-container>
+
+        <v-container>
+        <v-card-actions>
+            <!-- より詳細な検索条件の設定 -->
+            <v-tooltip bottom>
+                <template v-slot:activator="{on, attrs}">
+                    <v-btn 
+                    text
+                    @click="moreDetail=!moreDetail"
+                    v-bind="attrs"
+                    v-on="on"
+                    >
+                        <v-icon v-if="!moreDetail" small>
+                            mdi-details
+                        </v-icon>
+                        <v-icon v-if="moreDetail" x-small>
+                            mdi-triangle-outline
+                        </v-icon>
+                    </v-btn>
+                </template>
+                <span v-if="!moreDetail">Set more search details for filtering.</span>
+                <span v-if="moreDetail">Finish to set search details for filtering.</span>
+            </v-tooltip>
+        </v-card-actions>
+        </v-container>
+
+
+        <!-- 詳細検索設定 -->
+        <v-expand-transition>
+            <v-card
+                v-if="moreDetail"
+                class="transition-fast-in-fast-out v-card--moreDetail"
+                style="height: 100%;"
+                outlined>
+                <v-container>
+                    評価の下限
+                    <star-rating 
+                    v-model="rating"
+                    v-bind:increment="0.1"
+                    small />
+                </v-container>
+
+                <!-- 大学別検索 -->
+                <v-container>
+                    <v-btn-toggle
+                    v-model="nowUniv"
+                    group
+                    mandatory
+                    >
+                        <v-btn value="false" class="mx-auto" fab >
+                            <v-icon>
+                                mdi-alpha-a-circle-outline
+                            </v-icon>
+                        </v-btn>
+                        <v-btn value="true" class="mx-auto" fab >
+                            <v-icon>
+                                mdi-account-cowboy-hat
+                            </v-icon>
+                        </v-btn>
+                    </v-btn-toggle>
+                </v-container>
+            </v-card>
+        </v-expand-transition>
+        
+        <!-- 検索ボタン -->
+        <v-btn @click="Search(); dialog=false">
+            <v-icon>
+            mdi-card-search
+            </v-icon>
+        </v-btn> 
     </v-card>
-  </v-dialog>
+    </v-dialog>
 </template>
 
 <script>
 import {getSpotTypeDict} from "../../share/SpotTypeFunction"
+import StarRating from 'vue-star-rating'
 
 export default {
   data: function(){
@@ -99,11 +142,13 @@ export default {
       typeNameList: getSpotTypeDict('type'), //spot type object のkey配列作成 -> mountedで'reset'追加
       nowUniv:false,//現在の大学
       dialog:false,//検索ダイアログ表示管理
-      keyword:""
+      keyword:"",//検索キーワード
+      moreDetail:false,//詳細検索フォームの表示管理フラグ
+      rating:0,//評価の閾値
     }
   },
   components: {
-    //typeButton
+    StarRating
     },
   props:['spotNameList'],//スポット一覧
 
@@ -118,7 +163,7 @@ export default {
       Search(){
         //選ばれた検索条件をMapに送信
         var univFlag = (this.nowUniv=="true" ? true : false);
-        this.$emit('search',this.nowType,univFlag,this.keyword);
+        this.$emit('search',this.nowType,univFlag,this.keyword,this.rating);
       },
     }
     


### PR DESCRIPTION
### 【実装内容】
・マップの検索UIに詳細検索を導入し，大学別検索をそこに移動しました
・検索条件にスコアの下限を設定できるようにしました

### 【テスト手順】
1. map画面に行く
2. 左上のボタンから検索フォームを開く．
3. 検索フォームから大学検索のフォームが消えていることを確認する．
4. 検索フォームの三角のボタンの上にカーソルを乗せる．
5. ボタンの説明が表示されていることを確認する．
6. 三角のボタンをクリックする．
7. 下に入力フォームが増えることを確認する．
8. 星を適当な値に移動して，スポット評価の下限を入力する．
9. 大学検索フォームを適当に入力する．
10. 三角のボタンにカーソルを合わせ，表示内容がさっきと違うことを確認する．(ボタンを押せば詳細検索フォームが閉じます)
11. 検索ボタンを押す
12. 検索結果が入力した条件を満たしているかを確認する．

### 備考
いつの間にか，非ログイン時に大学検索を無効化する処理が働かなくなってるみたいなので，このプルリクで一緒に直しました．

### 【関連issue】
#133