### PR TITLE
既に登録されているemailでアカウントを作れないようにする

### DIFF
--- a/front/src/components/Signup/Signup.vue
+++ b/front/src/components/Signup/Signup.vue
@@ -89,7 +89,7 @@ import 'vue-select/dist/vue-select.css';
 Vue.component('v-select', vSelect);
 */
 
-import {register, getUser} from '../../routes/userRequest'
+import {register} from '../../routes/userRequest'
 import {getAllUniversities} from '../../routes/userRequest'
 const User = require("../../store/user");
 export default {
@@ -136,16 +136,18 @@ export default {
     methods: {
         createUser: async function() {
             if (!this.$refs.loginForm.validate()) return;
-            const users = await getUser(this.email);
-            if(users != "User does not exist") {
-                alert("this email is already used");
+            const res = await register(this.username,this.email,this.password,this.university);
+            if(!res.success) {
+                alert(res.error);
                 return;
             }
-            const res = await register(this.username,this.email,this.password,this.university);
-            //const userData = {"id":res.userId, "email":res.email, "username":res.userName}
-            const userData = new User(res.userId, res.userName, res.email, null, res.university)
-            this.$store.commit("login", userData)
-            this.$router.push('/map')
+            else {
+                //const userData = {"id":res.userId, "email":res.email, "username":res.userName}
+                const userData = new User(res.userId, res.userName, res.email, null, res.university)
+                this.$store.commit("login", userData)
+                this.$router.push('/map')
+            }
+
         },
     },
     

--- a/front/src/components/Signup/Signup.vue
+++ b/front/src/components/Signup/Signup.vue
@@ -89,7 +89,7 @@ import 'vue-select/dist/vue-select.css';
 Vue.component('v-select', vSelect);
 */
 
-import {register} from '../../routes/userRequest'
+import {register, getUser} from '../../routes/userRequest'
 import {getAllUniversities} from '../../routes/userRequest'
 const User = require("../../store/user");
 export default {
@@ -134,15 +134,18 @@ export default {
     },
 
     methods: {
-        createUser: function() {
+        createUser: async function() {
             if (!this.$refs.loginForm.validate()) return;
-            register(this.username,this.email,this.password,this.university)
-                .then(res => {
-                    //const userData = {"id":res.userId, "email":res.email, "username":res.userName}
-                    const userData = new User(res.userId, res.userName, res.email, null, res.university)
-                    this.$store.commit("login", userData)
-                    this.$router.push('/map')
-                });
+            const users = await getUser(this.email);
+            if(users != "User does not exist") {
+                alert("this email is already used");
+                return;
+            }
+            const res = await register(this.username,this.email,this.password,this.university);
+            //const userData = {"id":res.userId, "email":res.email, "username":res.userName}
+            const userData = new User(res.userId, res.userName, res.email, null, res.university)
+            this.$store.commit("login", userData)
+            this.$router.push('/map')
         },
     },
     

--- a/front/src/routes/userRequest.js
+++ b/front/src/routes/userRequest.js
@@ -15,7 +15,7 @@ async function register(userName, email, password, university){
         });
         return await reponse.json();
     }catch(exception){
-        return{success:false, data:exception};
+        return{success:false, error:exception};
     }
 }
 


### PR DESCRIPTION
### 実装内容
signup時に同じemailを使っているユーザーがいるか確認して，いなかった場合のみアカウントを作成するようにした．

### テスト手順
1. signupページに行く
2. emailの欄を他のアカウントで既に使われているものに設定する
3. 登録ボタンを押してアラートが出ることを確認
4. emailをまだ使われていないものに変更
5. 再度登録ボタンを押してアカウントが作られることを確認

### 関連issue
#198 