### PR TITLE
おすすめスポット2

### DIFF
--- a/front/src/components/UserProfile/UserProfile.vue
+++ b/front/src/components/UserProfile/UserProfile.vue
@@ -90,6 +90,10 @@ export default {
     methods: {    
         getSpotByUserId: async function(user_id){ // 作成スポット取得関数
             getSpot('', '', '', user_id, '').then(result => {
+                if( result.spots == undefined ){
+                    this.show_count += 1;
+                    return
+                }
                 const spot_length = result.spots.length
                 var i = 0;
                 for( var spt of result.spots ){
@@ -136,6 +140,10 @@ export default {
 
         getSpotYouReviewed: async function( user_id ){ //レビューしたスポット取得関数
             getReviewByUserId( user_id ).then( result => {
+                if( result.review == undefined ){
+                    this.show_count += 1;
+                    return
+                }
                 var reviewd_spot_ids = new Set()
                 for( let rev of result.review ){
                     reviewd_spot_ids.add( rev.spot_id );
@@ -220,6 +228,10 @@ export default {
 
         getRecommendedSpots: async function( user_univ ){ // おすすめスポット取得関数
             getSpot('', '', '', '', user_univ).then( result => {
+                if( result.spots == undefined ){
+                    this.show_count += 1;
+                    return
+                }
                 this.shuffleArray( result.spots ).then(result =>{
                     const spot_length = result.length
                     var i = 0;
@@ -250,16 +262,15 @@ export default {
                             }).finally(()=>{
                                 this.sortSpotsByScore( this.spot )
                                 this.spot = this.spot.slice( 0, 6 ) // 上位6件に限定
+                                i += 1;
+                                if (i==spot_length){
+                                    console.log("success getRecommendedSpots ")
+                                    this.show_count +=1;
+                                }
                             })
                         }).catch((exception => {
                             console.log("Error in getReviewBySpotId: ", exception)
-                        })).finally(()=>{
-                            i += 1;
-                            if (i==spot_length){
-                                console.log("success getRecommendedSpots ")
-                                this.show_count +=1;
-                            }
-                        });
+                        }));
                     }        
                 })
             }).catch((exception) => {

--- a/front/src/components/UserProfile/UserProfile.vue
+++ b/front/src/components/UserProfile/UserProfile.vue
@@ -19,8 +19,12 @@
 
 import userProfileDetail from "./UserProfileDetail.vue";
 import {getProfileImage} from "../../routes/imageRequest"
-import {SpotExampleData} from "../share/SpotExampleData";
-import {getSpotByUserId,getSpotYouReviewed} from '../share/GetProfileInformation.js';
+import {getSpot} from '../../routes/spotRequest';
+import {average} from '../../routes/reviewRequest';
+import {getReviewBySpotId, getReviewByUserId} from '../../routes/reviewRequest';
+import {getSpotImage} from "../../routes/imageRequest"
+// import {SpotExampleData} from "../share/SpotExampleData";
+// import {getSpotByUserId,getSpotYouReviewed,getRecommendedSpots} from '../share/GetProfileInformation.js';
 
 export default {
 
@@ -34,7 +38,7 @@ export default {
                 // ユーザー仮データ
             },
             isLoading: true,
-            spot: SpotExampleData(),
+            spot: [],
             my_spot: [
                 // 自分の作成したスポット
                 // required attribute: name, src, good
@@ -75,36 +79,206 @@ export default {
             return
         }
         
-        this.show_count = 0
         getProfileImage( this.user.id )
             .then(result => {
                 // console.log('test, UserProfile getProfileImage success')
                 if(!result.success) return;
                 this.user.src = "data:image/jpeg;base64," + result.data.image;
-            }) 
-
-        getSpotByUserId( this.user.id )
-            .then( result =>{
-                this.show_count += 1
-                this.my_spot = result
-        })
-
-        getSpotYouReviewed( this.user.id )
-            .then( result =>{
-                this.show_count += 1
-                this.good_spot = result
             })
+        
+        this.getSpotByUserId( this.user.id )
+        this.getSpotYouReviewed( this.user.id )
+        this.getRecommendedSpots( this.user.university )
+    },
+    methods: {    
+        getSpotByUserId: async function(user_id){ // 作成スポット取得関数
+            getSpot('', '', '', user_id, '').then(result => {
+                const spot_length = result.spots.length
+                var i = 0;
+                for( var spt of result.spots ){
+                    const spt_id = spt.spot_id;
+                    const name = spt.spot_name;
+
+                    // レビューの計算
+                    getReviewBySpotId(spt_id).then(result => {
+                        const scores = [];
+                        for (var rev of result.review) {
+                            scores.push(rev.score);
+                        }
+
+                        const good = Math.round(10 * average(scores)) / 10;
+                        getSpotImage(spt_id).then((result) => {
+                            if (result.success && result.data != undefined) {
+                                const src = "data:image/jpeg;base64," + result.data[0].image
+                                this.my_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                            } else {
+                                const src = require("@/assets/noimage.png");
+                                this.my_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                            }
+                        }).catch((exception) => {
+                            console.log("Error in getSpotImage: ", exception)
+                            const src = require("@/assets/noimage.png");
+                            this.my_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                        }).finally(()=>{
+                            i += 1;
+                            if (i==spot_length){
+                                this.show_count +=1;
+                                this.sortSpotsByScore( this.my_spot )
+                                console.log('success getSpotByUserId')
+                            }
+                        })
+                    }).catch((exception) => {
+                        console.log("Error in getReviewBySpotId: ", exception)
+                    })
+                }
+            }).catch((exception) => {
+                console.log( "Error in getSpotByUserId: ", exception );
+            })
+        },
+
+        getSpotYouReviewed: async function( user_id ){ //レビューしたスポット取得関数
+            getReviewByUserId( user_id ).then( result => {
+                var reviewd_spot_ids = new Set()
+                for( let rev of result.review ){
+                    reviewd_spot_ids.add( rev.spot_id );
+                }
+                // const all = reviewd_spot_ids.size;
+                // var added = 0;
+                const spot_length = reviewd_spot_ids.size
+                var i = 0;
+                for( let reviewd_spot_id of reviewd_spot_ids ){
+                    getSpot( reviewd_spot_id, '', '', '', '' ).then( result => {
+                        const spt = result.spots[ 0 ];
+                        const spt_id = spt.spot_id;
+                        const name = spt.spot_name;
+        
+                        // レビューの計算
+                        getReviewBySpotId(spt_id).then(result => {
+                            const scores = [];
+                            for (var rev of result.review) {
+                                scores.push(rev.score);
+                            }
+                            const good = Math.round(10 * average(scores)) / 10;
+                            getSpotImage(spt_id).then((result) => {
+                                if (result.success && result.data != undefined) {
+                                    const src = "data:image/jpeg;base64," + result.data[0].image
+                                    this.good_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                                } else {
+                                    const src = require("@/assets/noimage.png");
+                                    this.good_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                                }
+                            }).catch((exception) => {
+                                console.log("Error in getSpotImage: ", exception)
+                                const src = require("@/assets/noimage.png");
+                                this.good_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                            }).finally(()=>{
+                                i += 1;
+                                if (i==spot_length){
+                                    this.show_count +=1;
+                                    this.sortSpotsByScore( this.good_spot )
+                                    console.log("success getSpotYouReviewed ")
+                                }
+                            })
+                        }).catch((exception => {
+                            console.log("Error in getReviewBySpotId: ", exception);
+                        }));
+                    } ).catch((exception) => {
+                        console.log( "Error in getSpot: ", exception );
+                    })
+                }
+            } ).catch((exception) => {
+                console.log( "Error in getReviewByUserId: ", exception );
+            })
+        },
+
+        getLatestSpots: function( left = 0, right ,spot){ //スポットが多すぎるときの処理。
+            // TODO: 他のスポットにも対応
+            console.log( "latestSpots", ( spot ).slice( left, right ) )
+            return ( spot ).slice( left, right )
+        },
+
+        shuffleArray: async function( array ){ // 配列をシャッフルする関数
+            var newArray = [];
+            while ( array.length > 0 ) {
+                var n = array.length;
+                var k = Math.floor( Math.random() * n );
+
+                newArray.push( array[ k ] );
+                array.splice( k, 1 );
+            }
+            return newArray;
+        },
+
+        sortSpotsByScore: async function( array ){ // スポットをスコアの高い順にソートする関数
+            array.sort( function( a, b ){
+                if( a.good > b.good ){
+                    return -1
+                }else{
+                    return 1
+                }
+            } )
+        },
+
+        getRecommendedSpots: async function(user_univ){ // おすすめスポット取得関数
+            getSpot('', '', '', '', user_univ).then( result => {
+                this.shuffleArray( result.spots ).then(result =>{
+                    const spot_length = result.length
+                    var i = 0;
+                    for( var spt of result ){
+                        const spt_id = spt.spot_id;
+                        const name = spt.spot_name;
+
+                        // レビューの計算
+                        getReviewBySpotId(spt_id).then(result => {
+                            const scores = [];
+                            for (var rev of result.review) {
+                                scores.push(rev.score);
+                            }
+                            const good = Math.round(10 * average(scores)) / 10;
+                            
+                            getSpotImage(spt_id).then((result) => {
+                                if (result.success && result.data != undefined) {
+                                    const src = "data:image/jpeg;base64," + result.data[0].image
+                                    this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                                } else {
+                                    const src = require("@/assets/noimage.png");
+                                    this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                                }
+                            }).catch((exception) => {
+                                console.log("Error in getSpotImage: ", exception)
+                                const src = require("@/assets/noimage.png");
+                                this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                            }).finally(()=>{
+                                i += 1;
+                                this.sortSpotsByScore( this.spot )
+                                if (i==spot_length){
+                                    console.log("success getRecommendedSpots ")
+                                    this.show_count +=1;
+                                }
+                            })
+                        }).catch((exception => {
+                            console.log("Error in getReviewBySpotId: ", exception)
+                        }));
+                    }        
+                })
+            }).catch((exception) => {
+                console.log( "Error in getSpot: ", exception );
+            })
+        },
     },
     watch:  {
         show_count: function() {
-            if(this.show_count!=2) return;
-            if(this.show_count==2) {
+            if(this.show_count!=3) {
+                return
+            }
+
+            if(this.show_count==3) {
                 this.isLoading=false
-                // console.log('=========finish loading===========')
-                // console.log('my_spot',this.my_spot)
-                // console.log('good_spot',this.good_spot)
-                // console.log('user',this.user)
-                // console.log('otherUser',this.otherUser)
+                console.log('=========finish loading===========')
+                console.log('my_spot',this.my_spot)
+                console.log('good_spot',this.good_spot)
+                console.log('spot',this.spot)
+                console.log('==================================')
             }
         },
     },

--- a/front/src/components/UserProfile/UserProfile.vue
+++ b/front/src/components/UserProfile/UserProfile.vue
@@ -118,15 +118,16 @@ export default {
                             const src = require("@/assets/noimage.png");
                             this.my_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
                         }).finally(()=>{
-                            i += 1;
                             this.sortSpotsByScore( this.my_spot )
-                            if (i==spot_length){
-                                this.show_count +=1;
-                                console.log('success getSpotByUserId')
-                            }
                         })
                     }).catch((exception) => {
                         console.log("Error in getReviewBySpotId: ", exception)
+                    }).finally(()=>{
+                        i += 1;
+                        if (i==spot_length){
+                            this.show_count +=1;
+                            console.log('success getSpotByUserId')
+                        }
                     })
                 }
             }).catch((exception) => {
@@ -168,18 +169,19 @@ export default {
                                 const src = require("@/assets/noimage.png");
                                 this.good_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
                             }).finally(()=>{
-                                i += 1;
                                 this.sortSpotsByScore( this.good_spot )
-                                if (i==spot_length){
-                                    this.show_count +=1;
-                                    console.log("success getSpotYouReviewed ")
-                                }
                             })
                         }).catch((exception => {
                             console.log("Error in getReviewBySpotId: ", exception);
                         }));
                     } ).catch((exception) => {
                         console.log( "Error in getSpot: ", exception );
+                    }).finally(()=>{
+                        i += 1;
+                        if (i==spot_length){
+                            this.show_count +=1;
+                            console.log("success getSpotYouReviewed ")
+                        }
                     })
                 }
             } ).catch((exception) => {
@@ -217,7 +219,7 @@ export default {
             } )
         },
 
-        getRecommendedSpots: async function(user_univ){ // おすすめスポット取得関数
+        getRecommendedSpots: async function( user_univ ){ // おすすめスポット取得関数
             getSpot('', '', '', '', user_univ).then( result => {
                 this.shuffleArray( result.spots ).then(result =>{
                     const spot_length = result.length
@@ -247,17 +249,18 @@ export default {
                                 const src = require("@/assets/noimage.png");
                                 this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
                             }).finally(()=>{
-                                i += 1;
                                 this.sortSpotsByScore( this.spot )
-                                this.spot = this.spot.slice( 0, 6 ) // 上位6件に限定
-                                if (i==spot_length){
-                                    console.log("success getRecommendedSpots ")
-                                    this.show_count +=1;
-                                }
                             })
                         }).catch((exception => {
                             console.log("Error in getReviewBySpotId: ", exception)
-                        }));
+                        })).finally(()=>{
+                            i += 1;
+                            this.spot = this.spot.slice( 0, 6 ) // 上位6件に限定
+                            if (i==spot_length){
+                                console.log("success getRecommendedSpots ")
+                                this.show_count +=1;
+                            }
+                        });
                     }        
                 })
             }).catch((exception) => {

--- a/front/src/components/UserProfile/UserProfile.vue
+++ b/front/src/components/UserProfile/UserProfile.vue
@@ -119,9 +119,9 @@ export default {
                             this.my_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
                         }).finally(()=>{
                             i += 1;
+                            this.sortSpotsByScore( this.my_spot )
                             if (i==spot_length){
                                 this.show_count +=1;
-                                this.sortSpotsByScore( this.my_spot )
                                 console.log('success getSpotByUserId')
                             }
                         })
@@ -140,8 +140,6 @@ export default {
                 for( let rev of result.review ){
                     reviewd_spot_ids.add( rev.spot_id );
                 }
-                // const all = reviewd_spot_ids.size;
-                // var added = 0;
                 const spot_length = reviewd_spot_ids.size
                 var i = 0;
                 for( let reviewd_spot_id of reviewd_spot_ids ){
@@ -171,9 +169,9 @@ export default {
                                 this.good_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
                             }).finally(()=>{
                                 i += 1;
+                                this.sortSpotsByScore( this.good_spot )
                                 if (i==spot_length){
                                     this.show_count +=1;
-                                    this.sortSpotsByScore( this.good_spot )
                                     console.log("success getSpotYouReviewed ")
                                 }
                             })
@@ -271,9 +269,7 @@ export default {
         show_count: function() {
             if(this.show_count!=3) {
                 return
-            }
-
-            if(this.show_count==3) {
+            }else{
                 this.isLoading=false
             }
         },

--- a/front/src/components/UserProfile/UserProfile.vue
+++ b/front/src/components/UserProfile/UserProfile.vue
@@ -249,12 +249,12 @@ export default {
                                 this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
                             }).finally(()=>{
                                 this.sortSpotsByScore( this.spot )
+                                this.spot = this.spot.slice( 0, 6 ) // 上位6件に限定
                             })
                         }).catch((exception => {
                             console.log("Error in getReviewBySpotId: ", exception)
                         })).finally(()=>{
                             i += 1;
-                            this.spot = this.spot.slice( 0, 6 ) // 上位6件に限定
                             if (i==spot_length){
                                 console.log("success getRecommendedSpots ")
                                 this.show_count +=1;

--- a/front/src/components/UserProfile/UserProfile.vue
+++ b/front/src/components/UserProfile/UserProfile.vue
@@ -54,7 +54,6 @@ export default {
         }
     },
     mounted() {
-        // console.log('query:',this.otherUser)
         if(this.otherUser==true){
             this.user= { 
                 id: this.$store.state.otherUserData.userId,
@@ -81,7 +80,6 @@ export default {
         
         getProfileImage( this.user.id )
             .then(result => {
-                // console.log('test, UserProfile getProfileImage success')
                 if(!result.success) return;
                 this.user.src = "data:image/jpeg;base64," + result.data.image;
             })
@@ -207,6 +205,8 @@ export default {
                 array.splice( k, 1 );
             }
             return newArray;
+            // return newArray.slice( 0, 10 )
+            // みたいにすると，おすすめが毎回変わって面白いかも
         },
 
         sortSpotsByScore: async function( array ){ // スポットをスコアの高い順にソートする関数
@@ -251,6 +251,7 @@ export default {
                             }).finally(()=>{
                                 i += 1;
                                 this.sortSpotsByScore( this.spot )
+                                this.spot = this.spot.slice( 0, 6 ) // 上位6件に限定
                                 if (i==spot_length){
                                     console.log("success getRecommendedSpots ")
                                     this.show_count +=1;
@@ -274,11 +275,6 @@ export default {
 
             if(this.show_count==3) {
                 this.isLoading=false
-                console.log('=========finish loading===========')
-                console.log('my_spot',this.my_spot)
-                console.log('good_spot',this.good_spot)
-                console.log('spot',this.spot)
-                console.log('==================================')
             }
         },
     },

--- a/front/src/components/share/GetProfileInformation.js
+++ b/front/src/components/share/GetProfileInformation.js
@@ -89,10 +89,54 @@ async function getSpotYouReviewed( user_id ){
     })
 }
 
+async function getRecommendedSpot(user_univ){
+    return getSpot('', '', '', '', user_univ).then(result => {
+        var recommended_spot = []
+        var step = 0;
+        const goal = result.spots.length;
+        for( var spt of result.spots ){
+            const spt_id = spt.spot_id;
+            const name = spt.spot_name;
+
+            // レビューの計算
+            getReviewBySpotId(spt_id).then(result => {
+                const scores = [];
+                for (var rev of result.review) {
+                    scores.push(rev.score);
+                }
+
+                const good = Math.round(10 * average(scores)) / 10;
+                getSpotImage(spt_id).then((result) => {
+                    if (result.success && result.data != undefined) {
+                        const src = "data:image/jpeg;base64," + result.data[0].image
+                        recommended_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                    } else {
+                        const src = require("@/assets/noimage.png");
+                        recommended_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                    }
+                }).catch((exception) => {
+                    console.log("Error in getSpotImage: ", exception)
+                    const src = require("@/assets/noimage.png");
+                    recommended_spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                })
+            }).catch((exception) => {
+                console.log("Error in getReviewBySpotId: ", exception)
+            }).finally(()=>{
+                step += 1;
+                if( step >= goal ){
+                    return recommended_spot
+                }
+            })
+        }
+    }).catch((exception) => {
+        console.log( "Error in getSpotByUserId: ", exception );
+    })
+}
+
 async function getLatestSpots( left = 0, right ,spot){ //スポットが多すぎるときの処理。
     // TODO: 他のスポットにも対応
     console.log( "latestSpots", ( spot ).slice( left, right ) )
     return ( spot ).slice( left, right )
 }
 
-export {getSpotByUserId,getSpotYouReviewed,getLatestSpots}
+export {getSpotByUserId,getSpotYouReviewed,getRecommendedSpot,getLatestSpots}


### PR DESCRIPTION
### 実装
- ユーザーページのおすすめスポットのところに，おすすめスポットを表示できるようになりました．
    - 自分と同じ大学の人に投稿されたスポットのうち，複数人によってレビューされたものを評価の高い順に6件表示しています．
- 作成スポットとレビューしたスポットも評価の高い順にソートして表示できるようになりました．

### テスト
1. ログインする
2. ユーザーページにおすすめスポットが確認されることを確認
3. 各種スポットが評価の高い順に表示されることを確認

### 関連issue
#145

### メモ
- 別ファイルにmethodをまとめておく方が設計としてはきれいだと思うので時間があればリファクタリングしたい
- スポットの多いアカウントだとロードに時間がかかるけど，清水くんの作業が終われば改善される？