### PR TITLE
To do baby user spotdetail

### DIFF
--- a/front/src/components/SpotDetail/SpotDetail.vue
+++ b/front/src/components/SpotDetail/SpotDetail.vue
@@ -52,7 +52,7 @@
                         toolTip
                         color="gray"
                     />
-                    
+
                     <tag-type-icon v-for="type in typesToTags()" :key="type"
                         :type="type"
                         classType="mr-5"
@@ -120,7 +120,7 @@
                             <spot-review-register  
                                 v-if="this.$store.state.userData != null"
                                 :spot_id="spot_id"
-                                :spot_type="spotData.spot_type"
+                                :spot_type="typesToType()"
                                 @submit="updateDetail()"
                             />
                         </v-col>

--- a/front/src/components/UserProfile/SpotListCard.vue
+++ b/front/src/components/UserProfile/SpotListCard.vue
@@ -90,7 +90,7 @@
                             <v-toolbar-title
                                 class="px-2"
                             >
-                                {{ card.name }}
+                                {{ card.spotName }}
                             </v-toolbar-title>
               
                         <v-spacer></v-spacer>
@@ -123,7 +123,7 @@
             </v-card-actions>
 
         </v-container>
-        <spot-detail :showDialog="showDialog" :spot_id="selectedSpotID" @close="closeDialog()"/>
+        <spot-detail :showDialog="showDialog" :spot_id="selectedSpotID" :spot_name="selectedSpotName" :spot_type="selectedSpotType" :user_id="selectedUserID" @close="closeDialog()"/>
     </v-card>  
 </template>
 <script>
@@ -156,12 +156,17 @@
             num_per_page: 3, // 1ページの表示スポット数
             num_page: 1, // ページ数
             num_page_array: [ 10, 10, 10 ],
+            showNoCard: false,
+            //以下spotDetailへのprops渡し用変数
             showDialog: false,
             selectedSpotID: "",
-            showNoCard: false
+            selectedSpotName:"",
+            selectedSpotType:"",
+            selectedUserID:"",
         }),
         mounted() {
             this.spot = this.spot_list
+            console.log(this.spot)//debug
             // カテゴリ（おすすめ，作成，いいね）毎のページ数計算
             this.ChangeCategory( this.CategorySelect )
         },
@@ -216,6 +221,9 @@
                 // console.log("spotInformationPage: ", this.spot[value]) // Debug
                 this.showDialog = true;
                 this.selectedSpotID = this.spot[value].spotId;
+                this.selectedSpotName = this.spot[value].spotName;
+                this.selectedSpotType = this.spot[value].spotType;
+                this.selectedUserID = this.spot[value].userId;
             },
             // spotInformationPage: function(value) { // TODO: spotのカードをクリックしたときに動く関数
             //     console.log(this.spot_list[value].spotId) // Debug

--- a/front/src/components/share/GetProfileInformation.js
+++ b/front/src/components/share/GetProfileInformation.js
@@ -9,6 +9,8 @@ async function getSpotByUserId (user_id){
         for( var spt of result.spots ){
             const spt_id = spt.spot_id;
             const name = spt.spot_name;
+            const type = spt.spot_type;
+            const usr_id = spt.user_id;
 
             // レビューの計算
             //TODO : レビュー平均値表示
@@ -24,19 +26,19 @@ async function getSpotByUserId (user_id){
                     const src = "data:image/jpeg;base64," + result.data[0].image
                     //TODO : FIX
                     // my_spot.push( { "spotId": spt_id, "name": name, "src": src, "good": good } );
-                    my_spot.push({ "spotId": spt_id, "name": name, "src": src });
+                    my_spot.push({ "spotId": spt_id, "spotName": name, "spotType":type,"userId":usr_id, "src": src });
                 }else{
                     const src = require( "@/assets/noimage.png" );
                     //TODO : FIX
                     // my_spot.push( { "spotId": spt_id, "name": name, "src": src, "good": good } );
-                    my_spot.push({ "spotId": spt_id, "name": name, "src": src });
+                    my_spot.push({ "spotId": spt_id, "spotName": name, "spotType":type,"userId":usr_id, "src": src });
                 }
             }).catch((exception)=>{
                 console.log( "Error in getSpotImage: ", exception )
                 const src = require( "@/assets/noimage.png" );
                 //TODO : FIX
                 // my_spot.push( { "spotId": spt_id, "name": name, "src": src, "good": good } );
-                my_spot.push({ "spotId": spt_id, "name": name, "src": src });
+                my_spot.push({ "spotId": spt_id, "spotName": name, "spotType":type,"userId":usr_id,"src": src });
             })
         }
         return my_spot
@@ -59,6 +61,8 @@ async function getSpotYouReviewed( user_id ){
                 const spt = result.spots[ 0 ];
                 const spt_id = spt.spot_id;
                 const name = spt.spot_name;
+                const type = spt.spot_type;
+                const usr_id = spt.user_id;
  
                 // レビューの計算
                 // var scores = [];
@@ -73,17 +77,17 @@ async function getSpotYouReviewed( user_id ){
                     if( result.success && result.data != undefined ){
                         const src = "data:image/jpeg;base64," + result.data[0].image
                         // good_spot.push( { "spotId": spt_id, "name": name, "src": src, "good": good } );
-                        good_spot.push({ "spotId": spt_id, "name": name, "src": src });
+                        good_spot.push({ "spotId": spt_id, "spotName": name, "spotType":type,"userId":usr_id, "src": src });
                     }else{
                         const src = require( "@/assets/noimage.png" );
                         // good_spot.push( { "spotId": spt_id, "name": name, "src": src, "good": good } );
-                        good_spot.push({ "spotId": spt_id, "name": name, "src": src });
+                        good_spot.push({ "spotId": spt_id,"spotName": name, "spotType":type,"userId":usr_id, "src": src });
                     }
                 } ).catch((exception)=>{
                     console.log( "Error in getSpotImage: ", exception )
                     const src = require( "@/assets/noimage.png" );
                     // good_spot.push( { "spotId": spt_id, "name": name, "src": src, "good": good } );
-                    good_spot.push({ "spotId": spt_id, "name": name, "src": src });
+                    good_spot.push({ "spotId": spt_id, "spotName": name, "spotType":type,"userId":usr_id, "src": src });
                 })
             } ).catch((exception) => {
                 console.log( "Error in getReviewByUserId: ", exception );


### PR DESCRIPTION
ユーザーページからスポット詳細を見れないバグを修正

[test]
- ユーザーページにいく
- 作成スポットから任意のスポットをクリック
- スポット詳細を開けるかテスト

[備考]
- いくつかのスポットがspotdetailを開くと，ワーニングだらけになる(今のとこ動作は正常なので放置してる)