### PR TITLE
Fix search dialog bug

### DIFF
--- a/front/src/components/Map/MapButtons/SearchDialog.vue
+++ b/front/src/components/Map/MapButtons/SearchDialog.vue
@@ -143,12 +143,12 @@
                     group
                     mandatory
                     >
-                        <v-btn value="false" class="mx-auto" fab >
+                        <v-btn :value="false" class="mx-auto" fab >
                             <v-icon>
                                 mdi-alpha-a-circle-outline
                             </v-icon>
                         </v-btn>
-                        <v-btn value="true" class="mx-auto" fab >
+                        <v-btn :value="true" class="mx-auto" fab >
                             <v-icon>
                                 mdi-account-cowboy-hat
                             </v-icon>


### PR DESCRIPTION
#212 の「ログイン状態かつ，スポット検索ダイアログの詳細ボタン（矢印のやつ）を一回以上押した状態で検索ボタンを押したら，スポットを取ってこれなくなる」を修正

- テスト: 詳細検索で，大学検索をした後に全体で検索してスポットが全て表示されることを確認