### PR TITLE
スポット登録/更新後に正しくページ遷移しない

### DIFF
--- a/front/src/components/Map/Map.vue
+++ b/front/src/components/Map/Map.vue
@@ -8,7 +8,7 @@
         <!-- 現在地ボタン -->
         <now-loc-button v-on:click.native="setNowLocation()"/>
         <map-loading v-if="isLoadingSpot"/>
-        <spot-detail :showDialog="showDialog" :spot_id="selectedSpotID" :spot_name="selectedSpotName" :spot_type="selectedSpotType" :user_id="selectedSpotUserId" @close="closeDialog()"/>
+        <spot-detail :showDialog="showDialog" :spot_id="selectedSpotID" :user_id="selectedSpotUserId" @close="closeDialog()"/>
     </div>  
 </template>
 

--- a/front/src/components/SpotDetail/SpotDetail.vue
+++ b/front/src/components/SpotDetail/SpotDetail.vue
@@ -156,6 +156,7 @@ import spotReviewRegister from './SpotReviewRegister.vue'
 import spotEdit from './SpotEdit.vue'
 import radarChartDisp from '../share/RadarChartDisp'
 import {average, getReviewBySpotId} from '../../routes/reviewRequest'
+import {getSpot} from '../../routes/spotRequest'
 import {getSpotImage} from '../../routes/imageRequest'
 import { getUserById } from '../../routes/userRequest.js'
 import {getProfileImage} from "../../routes/imageRequest"
@@ -200,8 +201,6 @@ export default {
     props: {
         spot_id: String,
         showDialog: Boolean,
-        spot_name: String,
-        spot_type: String,
         user_id: String
     },
     methods: {
@@ -230,7 +229,12 @@ export default {
         },
         updateDetail: function() {
             this.isLoadingData = true;      // データを取得している間はローディング画面を表示する
-            this.isLoadingPhoto = true;      
+            this.isLoadingPhoto = true; 
+            getSpot(this.spot_id, "", "", "", "")
+                .then(res => {
+                    this.spotData.spot_name = res.spots[0].spot_name;
+                    this.spotData.spot_type = res.spots[0].spot_type;
+                })     
             getReviewBySpotId(this.spot_id, "", "", "", "")
                 .then(res => {
                     this.reviews = res.review;
@@ -338,8 +342,6 @@ export default {
     watch: {
         showDialog: function() {    //spot詳細ダイアログが開いた(閉じた)時に実行するメソッド
             if(!this.showDialog) return;
-            this.spotData.spot_name=this.spot_name;
-            this.spotData.spot_type=this.spot_type;
             this.spotData.user_id=this.user_id;
             this.updateDetail()
             this.now_review_page = 1;

--- a/front/src/components/SpotRegister/SpotRegister.vue
+++ b/front/src/components/SpotRegister/SpotRegister.vue
@@ -49,12 +49,15 @@ export default {
             saveSpot(spotData.name, this.$route.query.lon, this.$route.query.lat, "", spotData.types + "," + spotData.tags, spotData.userId, spotData.comment, spotData.scores, spotData.university)
                 .then(res => {
                     if(!res.success) return
-                    if(imageFile == undefined) return 
+                    if(imageFile == undefined) {
+                        this.$router.push('/map')
+                        return 
+                    }
                     uploadSpotImage(imageFile, res.spotId)
                         .then(res => {
                             console.log(res)
+                            this.$router.push('/map')
                         })
-                    this.$router.push('/map')
                 })
         },
         OnCancel: function() {

--- a/front/src/components/UserProfile/SpotListCard.vue
+++ b/front/src/components/UserProfile/SpotListCard.vue
@@ -123,7 +123,7 @@
             </v-card-actions>
 
         </v-container>
-        <spot-detail :showDialog="showSpotDialog" :spot_id="selectedSpotID" :spot_name="selectedSpotName" :spot_type="selectedSpotType" :user_id="selectedUserID" @close="closeSpotDialog()"/>
+        <spot-detail :showDialog="showSpotDialog" :spot_id="selectedSpotID" :user_id="selectedUserID" @close="closeSpotDialog()"/>
     </v-card>  
 </template>
 <script>


### PR DESCRIPTION
スポット登録/更新後のバグを修正

### 確認事項
1. 新規スポット作成後にマップに遷移し、選択した地点にスポットマーカーが表示されている
2. スポット情報を更新した後に詳細画面に戻り、変更した内容が反映されている