### PR TITLE
Mapに関わる微修正

### DIFF
--- a/front/src/components/Map/Map.js
+++ b/front/src/components/Map/Map.js
@@ -102,8 +102,7 @@ export default {
         //Map上のどこかををクリックした時に起動する関数
         mapClickEvent(event){
             if(this.$store.state.userData!=null){
-            
-            if(this.flag){
+                if(this.flag){
                 this.flag=false
                 this.getPoint(event);
                 this.regSpot(event);

--- a/front/src/components/Map/Map.js
+++ b/front/src/components/Map/Map.js
@@ -101,11 +101,14 @@ export default {
         // },
         //Map上のどこかををクリックした時に起動する関数
         mapClickEvent(event){
+            if(this.$store.state.userData!=null){
+            
             if(this.flag){
                 this.flag=false
                 this.getPoint(event);
                 this.regSpot(event);
             }else{this.flag=true;}
+        }
         },
 
         //Map上のクリックされた箇所の経緯度を取得する関数

--- a/front/src/components/Map/MapButtons/SearchDialog.vue
+++ b/front/src/components/Map/MapButtons/SearchDialog.vue
@@ -118,8 +118,8 @@
                         </v-icon>
                     </v-btn>
                 </template>
-                <span v-if="!moreDetail">Set more search details for filtering.</span>
-                <span v-if="moreDetail">Finish to set search details for filtering.</span>
+                <span v-if="!moreDetail">より詳細な検索</span>
+                <span v-if="moreDetail">詳細検索を閉じる</span>
             </v-tooltip>
         </v-card-actions>
         </v-container>
@@ -156,7 +156,7 @@
                                     mdi-alpha-a-circle-outline
                                 </v-icon>
                             </template>
-                            <span>Show all spots regardless of the university.</span>
+                            <span>全ての所属大学のスポットを表示</span>
                             </v-tooltip>
                         </v-btn>
                         
@@ -167,7 +167,7 @@
                                     mdi-account-cowboy-hat
                                 </v-icon>
                             </template>
-                            <span>Show only spots of your university.</span>
+                            <span>あなたの所属大学のスポットを表示</span>
                             </v-tooltip>
                         </v-btn>
                     </v-btn-toggle>

--- a/front/src/components/Map/MapButtons/SearchDialog.vue
+++ b/front/src/components/Map/MapButtons/SearchDialog.vue
@@ -189,7 +189,7 @@
                         <v-icon> mdi-file-refresh </v-icon>
                     </v-btn> 
                 </template>
-                <span> Clear all your input.</span>
+                <span> 入力をクリア </span>
             </v-tooltip>
         </v-container>
     </v-card>


### PR DESCRIPTION
### 実装内容
Mapのデプロイテストを受けての微修正

### テスト1(非ログイン切り替え時のバグ対応)
1. ログイン状態でマップ画面を開く
2. map上の右上のボタンを1回押してスポット登録モードに変更
3. ヘッダからログアウト
4. マップ上の任意の点をクリックして，登録画面に遷移しないことを確認

### テスト2( 検索ダイアログのツールチップ表示)
1. マップ画面を開く
2. 検索アイアログを開く
3. 詳細検索のボタンにカーソルし，メッセージが日本語になっていることを確認
4. ダイアログを開き，その中身の大学検索のボタンにカーソルし，同じく日本語になっていることを確認