### PR TITLE
Feature/191 user bug fix

### DIFF
--- a/front/src/components/SpotDetail/SpotEdit.vue
+++ b/front/src/components/SpotDetail/SpotEdit.vue
@@ -31,7 +31,6 @@ export default {
 
     methods: {
         onUpdate: function(spotData, imageFile) {
-            console.log(this.spotId, spotData.name, spotData.types + "," + spotData.tags);
             editSpot(this.spotId, spotData.name, spotData.types + "," + spotData.tags)
                 .then(res => {
                     if(!res.success || imageFile == undefined) {

--- a/front/src/components/SpotDetail/SpotReviewRegister.vue
+++ b/front/src/components/SpotDetail/SpotReviewRegister.vue
@@ -102,13 +102,12 @@ export default {
     methods: {
         onClickedRegisterButton: function() {
             this.showDialog = false;
-            console.log(this.spot_id);
-            for(var i = 0; i < 5; i++) {
-                console.log("score " + i + ": " + this.review_data.scores[i]);
-            }
+            // for(var i = 0; i < 5; i++) {
+            //     console.log("score " + i + ": " + this.review_data.scores[i]);
+            // }
             saveReview(this.spot_id, this.review_data.comment, this.review_data.scores, this.$store.state.userData.userId)
                 .then(res => {
-                    console.log('saveReview response:',res)        // Debug
+                    // console.log('saveReview response:',res)        // Debug
                     this.$emit('submit')
                 })
         },

--- a/front/src/components/SpotDetail/SpotReviewRegister.vue
+++ b/front/src/components/SpotDetail/SpotReviewRegister.vue
@@ -102,12 +102,9 @@ export default {
     methods: {
         onClickedRegisterButton: function() {
             this.showDialog = false;
-            // for(var i = 0; i < 5; i++) {
-            //     console.log("score " + i + ": " + this.review_data.scores[i]);
-            // }
             saveReview(this.spot_id, this.review_data.comment, this.review_data.scores, this.$store.state.userData.userId)
                 .then(res => {
-                    // console.log('saveReview response:',res)        // Debug
+                    if(!res.success) return
                     this.$emit('submit')
                 })
         },

--- a/front/src/components/SpotRegister/SpotInputForm.vue
+++ b/front/src/components/SpotRegister/SpotInputForm.vue
@@ -289,7 +289,6 @@ export default {
     },
 
     mounted: function() {
-        console.log(this.initialSpotData)
         this.spot_data.name = this.initialSpotData.spot_name;
         this.spot_data.types = this.initialSpotData.spot_type.split(",")[0];
         this.spot_data.scores = this.initialScores;

--- a/front/src/components/SpotRegister/SpotRegister.vue
+++ b/front/src/components/SpotRegister/SpotRegister.vue
@@ -45,7 +45,6 @@ export default {
 
     methods: {
         OnRegister: function(spotData, imageFile) {
-            console.log(spotData)
             saveSpot(spotData.name, this.$route.query.lon, this.$route.query.lat, "", spotData.types + "," + spotData.tags, spotData.userId, spotData.comment, spotData.scores, spotData.university)
                 .then(res => {
                     if(!res.success) return

--- a/front/src/components/UserProfile/SpotListCard.vue
+++ b/front/src/components/UserProfile/SpotListCard.vue
@@ -203,8 +203,7 @@
                         this.end = spot_length
                     }
                     var j = this.begin;
-                    // console.log(this.begin)
-                    // console.log(this.end)
+                    
                     for(let i = this.begin; i < this.end; i++){
                         const spt = result.spots[i];
                         const spt_id = spt.spot_id;

--- a/front/src/components/UserProfile/SpotListCard.vue
+++ b/front/src/components/UserProfile/SpotListCard.vue
@@ -203,8 +203,8 @@
                         this.end = spot_length
                     }
                     var j = this.begin;
-                    console.log(this.begin)
-                    console.log(this.end)
+                    // console.log(this.begin)
+                    // console.log(this.end)
                     for(let i = this.begin; i < this.end; i++){
                         const spt = result.spots[i];
                         const spt_id = spt.spot_id;

--- a/front/src/components/UserProfile/SpotListCard.vue
+++ b/front/src/components/UserProfile/SpotListCard.vue
@@ -130,7 +130,7 @@
                     </v-col>
                 </v-card-actions>
             </v-container>
-            <spot-detail :showDialog="showSpotDialog" :spot_id="selectedSpotID" :spot_name="selectedSpotName" :spot_type="selectedSpotType" :user_id="selectedUserID" @close="closeSpotDialog()"/>
+            <spot-detail :showDialog="showSpotDialog" :spot_id="selectedSpotID" :user_id="selectedUserID" @close="closeSpotDialog()"/>
         </v-card>  
     </v-container>
 </template>
@@ -171,8 +171,8 @@
             isLoading: true,
             userId: "",
             university: "",
-            selectedSpotName:"",
-            selectedSpotType:"",
+            // selectedSpotName:"", // 未使用
+            // selectedSpotType:"", // 未使用
             selectedUserID:"",
         }),
         mounted() {
@@ -220,15 +220,15 @@
                             getSpotImage(spt_id).then((result) => {
                                 if (result.success && result.data != undefined) {
                                     const src = "data:image/jpeg;base64," + result.data[0].image
-                                    this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                                    this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good, "userId" : user_id });
                                 } else {
                                     const src = require("@/assets/noimage.png");
-                                    this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                                    this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good, "userId" : user_id });
                                 }
                             }).catch((exception) => {
                                 console.log("Error in getSpotImage: ", exception)
                                 const src = require("@/assets/noimage.png");
-                                this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                                this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good, "userId" : user_id });
                             }).finally(()=>{
                                 j += 1;
                                 if(j == this.end){
@@ -294,15 +294,15 @@
                                 getSpotImage(spt_id).then((result) => {
                                     if (result.success && result.data != undefined) {
                                         const src = "data:image/jpeg;base64," + result.data[0].image
-                                        this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                                        this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good, "userId" : spt.user_id });
                                     } else {
                                         const src = require("@/assets/noimage.png");
-                                        this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                                        this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good, "userId" : spt.user_id });
                                     }
                                 }).catch((exception) => {
                                     console.log("Error in getSpotImage: ", exception)
                                     const src = require("@/assets/noimage.png");
-                                    this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good });
+                                    this.spot.push({ "spotId": spt_id, "name": name, "src": src, "good": good, "userId" : spt.user_id });
                                 }).finally(()=>{
                                     j += 1;
                                     if(j == this.end){
@@ -358,15 +358,15 @@
                             getSpotImage(spt.spot_id).then((result) => {
                                 if (result.success && result.data != undefined) {
                                     const src = "data:image/jpeg;base64," + result.data[0].image
-                                    this.spot.push({ "spotId": spt.spot_id, "name": spt.spot_name, "src": src, "good": good });
+                                    this.spot.push({ "spotId": spt.spot_id, "name": spt.spot_name, "src": src, "good": good, "userId" : spt.user_id });
                                 } else {
                                     const src = require("@/assets/noimage.png");
-                                    this.spot.push({ "spotId": spt.spot_id, "name": spt.spot_name, "src": src, "good": good });
+                                    this.spot.push({ "spotId": spt.spot_id, "name": spt.spot_name, "src": src, "good": good, "userId" : spt.user_id });
                                 }
                             }).catch((exception) => {
                                 console.log("Error in getSpotImage: ", exception)
                                 const src = require("@/assets/noimage.png");
-                                this.spot.push({ "spotId": spt.spot_id, "name": spt.spot_name, "src": src, "good": good });
+                                this.spot.push({ "spotId": spt.spot_id, "name": spt.spot_name, "src": src, "good": good, "userId" : spt.user_id });
                             }).finally(()=>{
                                 j += 1;
                                 if(j == this.end){
@@ -430,8 +430,8 @@
             spotInformationPage: function(value) { 
                 this.showSpotDialog = true;
                 this.selectedSpotID = this.spot[value].spotId;
-                this.selectedSpotName = this.spot[value].name;
-                this.selectedSpotType = this.spot[value].spotType;
+                // this.selectedSpotName = this.spot[value].name; // 未使用
+                // this.selectedSpotType = this.spot[value].spotType; // 未使用
                 this.selectedUserID = this.spot[value].userId;
             },
             closeSpotDialog() {


### PR DESCRIPTION
### 実装
- ユーザーページでスポット情報修正・削除できないバグ修正
- コンソールにID情報など出力されないように修正

### テスト1（ ユーザーページでスポット情報修正・削除できないバグ修正）
1. ユーザーページに行く
1. スポットのサイドバーをクリックし、作成スポットを選択
1. 自分の作成したスポットをクリック
1. スポット情報が修正・削除できることを確認
2. 自分が作成していないスポットをクリック
3. スポット情報を変更・削除できないことを確認

### テスト2（コンソール削除）
以下の条件の時のコンソール削除
- spot登録時
- レビュー投稿時
- スポット情報修正時

### 関連issue
#191